### PR TITLE
Fix no query variables exception issue.

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -54,7 +54,7 @@ defmodule Absinthe.Plug do
     """)
 
     with input when is_binary(input) <- input,
-      {:ok, variables} <- decode_variables(json_codec, variables) do
+      variables <- decode_variables(json_codec, variables) do
         %{variables: variables,
           adapter: config.adapter,
           context: Map.merge(config.context, conn.private[:absinthe][:context] || %{}),
@@ -124,5 +124,5 @@ defmodule Absinthe.Plug do
       {:error, _} -> %{} # Even express-graphql ignores these errors currently
     end
   end
-  defp decode_variables(_, variables), do: {:ok, variables}
+  defp decode_variables(_, variables), do: variables
 end

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -45,7 +45,7 @@ defmodule Absinthe.Plug do
     {body, conn} = load_body_and_params(conn)
 
     input = Map.get(conn.params, "query", body || :input_error)
-    variables = Map.get(conn.params, "variables") || "{}"
+    variables = Map.get(conn.params, "variables", %{})
     operation_name = conn.params["operationName"]
 
     Logger.debug("""
@@ -54,7 +54,7 @@ defmodule Absinthe.Plug do
     """)
 
     with input when is_binary(input) <- input,
-      {:ok, variables} <- json_codec.module.decode(variables) do
+      {:ok, variables} <- decode_variables(json_codec, variables) do
         %{variables: variables,
           adapter: config.adapter,
           context: Map.merge(config.context, conn.private[:absinthe][:context] || %{}),
@@ -117,4 +117,12 @@ defmodule Absinthe.Plug do
     {:http_error, "Can only perform a #{operation} from a POST request"}
   end
   defp validate_http_method(_, _), do: :ok
+  
+  defp decode_variables(json_codec, variables) when is_binary(variables) do
+    case json_codec.module.decode(variables) do
+      {:ok, variables} -> variables
+      {:error, _} -> %{} # Even express-graphql ignores these errors currently
+    end
+  end
+  defp decode_variables(_, variables), do: {:ok, variables}
 end


### PR DESCRIPTION
Currently the plug doesn't allow one to query without variables and raises the following:

```
** (exit) an exception was raised:
        ** (ArgumentError) argument error
            :erlang.iolist_to_binary(%{})
            (poison) lib/poison/parser.ex:35: Poison.Parser.parse/2
            (poison) lib/poison.ex:69: Poison.decode/2
```

This is because the variables passed to be decoded are expected to be `iodata`.

This is to also accomodate for queries as described here: facebook/relay#112