### PR TITLE
fix params query when is unfetched

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -100,7 +100,7 @@ defmodule Absinthe.Plug do
     """)
 
     variables = Map.get(conn.params, "variables") || "{}"
-    operation_name = conn.params["operationName"]
+    operation_name = Map.get(conn.params, "operationName")
 
     with {:ok, variables} <- decode_variables(variables, json_codec) do
         absinthe_opts = %{


### PR DESCRIPTION
When using plug without phoenix I was getting this error:

```
    ** (exit) an exception was raised:
    ** (UndefinedFunctionError) function Plug.Conn.Unfetched.fetch/2 is undefined (Plug.Conn.Unfetched does not implement the Access behaviour)
        (plug) Plug.Conn.Unfetched.fetch(%Plug.Conn.Unfetched{aspect: :params}, "operationName")
        (elixir) lib/access.ex:148: Access.fetch/2
        (elixir) lib/access.ex:179: Access.get/3
        lib/absinthe/plug.ex:103: Absinthe.Plug.prepare/3
        lib/absinthe/plug.ex:83: Absinthe.Plug.execute/2
        lib/absinthe/plug.ex:54: Absinthe.Plug.call/2
        (plug) lib/plug/router/utils.ex:74: Plug.Router.Utils.forward/4
        (app) lib/app/router.ex:1: App.Router.plug_builder_call/2
```

This PR fix this.