### PR TITLE
Update Graphiql to 0.7.8

### DIFF
--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -12,7 +12,7 @@ defmodule Absinthe.Plug.GraphiQL do
   """
 
   require EEx
-  @graphiql_version "0.7.1"
+  @graphiql_version "0.7.8"
   EEx.function_from_file :defp, :graphiql_html, Path.join(__DIR__, "graphiql.html.eex"),
     [:graphiql_version, :query_string, :variables_string, :result_string]
 

--- a/lib/absinthe/plug/graphiql.html.eex
+++ b/lib/absinthe/plug/graphiql.html.eex
@@ -18,8 +18,8 @@ add "&raw" to the end of the URL within a browser.
   </style>
   <link href="//cdn.jsdelivr.net/graphiql/<%= graphiql_version %>/graphiql.css" rel="stylesheet" />
   <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.0.2/react.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.0.2/react-dom.min.js"></script>
+  <script src="//cdn.jsdelivr.net/react/15.3.0/react.min.js"></script>
+  <script src="//cdn.jsdelivr.net/react/15.3.0/react-dom.min.js"></script>
   <script src="//cdn.jsdelivr.net/graphiql/<%= graphiql_version %>/graphiql.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
This most notably provide support for GraphQL@0.7.0 (Since version 0.7.6) as well as new features and bug fixes.