### PR TITLE
Parse empty operation name as nil

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -100,7 +100,7 @@ defmodule Absinthe.Plug do
     """)
 
     variables = Map.get(conn.params, "variables") || "{}"
-    operation_name = conn.params["operationName"]
+    operation_name = conn.params["operationName"] |> decode_operation_name
 
     with {:ok, variables} <- decode_variables(variables, json_codec) do
         absinthe_opts = %{
@@ -115,6 +115,10 @@ defmodule Absinthe.Plug do
   defp validate_input(nil), do: {:input_error, "No query document supplied"}
   defp validate_input(""), do: {:input_error, "No query document supplied"}
   defp validate_input(doc), do: {:ok, doc}
+
+  # GraphQL.js treats an empty operation name as no operation name.
+  defp decode_operation_name(""), do: nil
+  defp decode_operation_name(name), do: name
 
   defp decode_variables(%{} = variables, _), do: {:ok, variables}
   defp decode_variables("", _), do: {:ok, %{}}

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -86,6 +86,17 @@ defmodule Absinthe.PlugTest do
     assert resp_body == @foo_result
   end
 
+  test "content-type application/json works with empty operation name" do
+    opts = Absinthe.Plug.init(schema: TestSchema)
+
+    assert %{status: 200, resp_body: resp_body} = conn(:post, "/", Poison.encode!(%{query: @query, operationName: ""}))
+    |> put_req_header("content-type", "application/json")
+    |> plug_parser
+    |> Absinthe.Plug.call(opts)
+
+    assert resp_body == @foo_result
+  end
+
   @mutation """
   mutation AddItem {
     addItem(name: "Baz") {


### PR DESCRIPTION
Rationale from the commit message:

> Some clients e.g. apollo-client [send an empty string][0] instead of `null` as
> the operation name when there is none. The graphql-js reference implementation
> [accepts it][1] as that empty string is falsey. I'm not sure if that's intended
> but since the reference supports it then Absinthe should probably support it as
> well.

Please let me know what you think of this and whether any changes are needed. Thanks!

[0]: https://github.com/apollostack/apollo-client/blob/3ae8b71/src/queries/getFromAST.ts#L52
[1]: https://github.com/graphql/graphql-js/blob/988508c/src/execution/execute.js#L195