### PR TITLE
Add Absinthe.Parser for Plug.Parsers

### DIFF
--- a/lib/absinthe/parser.ex
+++ b/lib/absinthe/parser.ex
@@ -1,0 +1,25 @@
+defmodule Absinthe.Parser do
+  @moduledoc """
+  Extracts the graphql request body.
+  """
+
+  @behaviour Plug.Parsers
+  alias Plug.Conn
+
+  def parse(conn, "application", "graphql", _headers, opts) do
+    case Conn.read_body(conn, opts) do
+      {:ok, body, conn} ->
+        {:ok, %{"query" => body}, conn}
+      {:more, _data, conn} ->
+        {:error, :too_large, conn}
+      {:error, :timeout} ->
+        raise Plug.TimeoutError
+      {:error, _} ->
+        raise Plug.BadRequestError
+    end
+  end
+
+  def parse(conn, _type, _subtype, _headers, _opts) do
+    {:next, conn}
+  end
+end

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -156,7 +156,7 @@ defmodule Absinthe.Plug do
     end
   end
 
-  def load_body_and_params(%{body_params: %{"query" => query}}=conn) do
+  def load_body_and_params(%{body_params: %{"query" => _}}=conn) do
     {fetch_query_params(conn), ""}
   end
   def load_body_and_params(conn) do

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -156,6 +156,9 @@ defmodule Absinthe.Plug do
     end
   end
 
+  def load_body_and_params(%{body_params: %{"query" => query}}=conn) do
+    {fetch_query_params(conn), ""}
+  end
   def load_body_and_params(conn) do
     case get_req_header(conn, "content-type") do
       ["application/graphql"] ->

--- a/lib/absinthe/plug/parser.ex
+++ b/lib/absinthe/plug/parser.ex
@@ -1,4 +1,4 @@
-defmodule Absinthe.Parser do
+defmodule Absinthe.Plug.Parser do
   @moduledoc """
   Extracts the graphql request body.
   """

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Absinthe.Plug.Mixfile do
 
   defp deps do
     [
-      {:plug, "~> 1.0"},
+      {:plug, "~> 1.2"},
       {:absinthe, "~> 1.2.0"},
       {:poison, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.11.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"absinthe": {:hex, :absinthe, "1.2.1", "67099c701aca32c8f5cc8a0147d578eaecccf1bcb460edc746d467ccc7881ed8", [:mix], []},
   "earmark": {:hex, :earmark, "0.1.19", "ffec54f520a11b711532c23d8a52b75a74c09697062d10613fa2dbdf8a9db36e", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.2", "8ac82c6144a27faca6a623eeebfbf5a791bc20a54ce29a9c02e499536d253d9b", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "plug": {:hex, :plug, "1.0.3", "8bbcbdaa4cb15170b9a15cb12153e8a6d9e176ce78e4c1990ea0b505b0ca24a0", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
+  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "plug": {:hex, :plug, "1.3.0", "6e2b01afc5db3fd011ca4a16efd9cb424528c157c30a44a0186bcc92c7b2e8f3", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "1.5.0", "f2f4f460623a6f154683abae34352525e1d918380267cdbd949a07ba57503248", [:mix], []}}

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -205,7 +205,7 @@ defmodule Absinthe.PlugTest do
 
   defp plug_parser(conn) do
     opts = Plug.Parsers.init(
-      parsers: [:urlencoded, :multipart, :json, Absinthe.Parser],
+      parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
       json_decoder: Poison
     )
     Plug.Parsers.call(conn, opts)


### PR DESCRIPTION
@benwilson512 We talked about this idea earlier on Slack. I don't know if you would want to pull this into the library (it'd be a breaking change) but I thought it was interesting what I found while implementing it.

The parser itself is pretty straightforward, and the function `load_body_and_params` inside the Absinthe plug can go away.

I couldn't find anything about `x-www-urlencoded`, but plenty about `x-www-form-urlencoded`, which is handled by the built-in `:urlencoded` parser. With that change in the test setup, and the addition of the `Absinthe.Parser` for GraphQl, we don't need to allow wildcard content type with `pass: ["*/*"]`.

With these changes, the parsers would be configured more like this:

```elixir
plug Plug.Parsers,
  parsers: [:urlencoded, :multipart, :json, Absinthe.Parser],
  json_decoder: Poison
```