### PR TITLE
Allow application/graphql with encoding

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -169,6 +169,9 @@ defmodule Absinthe.Plug do
       ["application/graphql"] ->
         {:ok, body, conn} = read_body(conn)
         {fetch_query_params(conn), body}
+      [<<"application/graphql;", _ :: binary>>] ->
+        {:ok, body, conn} = read_body(conn)
+        {fetch_query_params(conn), body}
       _ ->
         {conn, ""}
     end

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -52,6 +52,26 @@ defmodule Absinthe.PlugTest do
     assert resp_body == @foo_result
   end
 
+  test "content-type application/graphql with encoding works" do
+    opts = Absinthe.Plug.init(schema: TestSchema)
+
+    assert %{status: 200, resp_body: resp_body} = conn(:post, "/", @query)
+    |> put_req_header("content-type", "application/graphql; charset=UTF-8")
+    |> Absinthe.Plug.call(opts)
+
+    assert resp_body == @foo_result
+  end
+
+  test "content-type application/graphql with encoding works with variables" do
+    opts = Absinthe.Plug.init(schema: TestSchema)
+
+    assert %{status: 200, resp_body: resp_body} = conn(:post, ~s(/?variables={"id":"foo"}), @variable_query)
+    |> put_req_header("content-type", "application/graphql; charset=UTF-8")
+    |> Absinthe.Plug.call(opts)
+
+    assert resp_body == @foo_result
+  end
+
   test "content-type application/x-www-form-urlencoded works" do
     opts = Absinthe.Plug.init(schema: TestSchema)
 


### PR DESCRIPTION
Fix for the bug discussed in https://github.com/absinthe-graphql/absinthe_plug/issues/44