### PR TITLE
Add no-referrer header

### DIFF
--- a/lib/absinthe/plug/graphiql.html.eex
+++ b/lib/absinthe/plug/graphiql.html.eex
@@ -8,6 +8,7 @@ add "&raw" to the end of the URL within a browser.
 <!DOCTYPE html>
 <html>
 <head>
+  <meta name="referrer" content="no-referrer" />
   <style>
     html, body {
       height: 100%;


### PR DESCRIPTION
No-referrer header to prevent long queries stored in the URL bar `location` from being sent as referrer headers. Long headers can cause cowboy to silently drop the request.