### PR TITLE
Custom adapter not passed through to absinthe pipeline/run function

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -193,6 +193,12 @@ defmodule Absinthe.Plug do
           root_value: (conn.private[:absinthe][:root_value] || %{}),
           operation_name: operation_name,
         ]
+        absinthe_opts =
+          if not(is_nil(config.adapter)) do
+            Keyword.put(absinthe_opts, :adapter, config.adapter)
+          else
+            absinthe_opts
+          end
         {:ok, raw_input, absinthe_opts}
     end
   end


### PR DESCRIPTION
Related to [the adapter fix made here](https://github.com/absinthe-graphql/absinthe/pull/265), adapters are not being passed through properly via:

```
  plug Absinthe.Plug,
    adapter: SuperSavvyLanguageAdapter,
    schema: Web.GraphQL.Schema
```