### PR TITLE
Upgrade to GraphiQL version 0.9.3

### DIFF
--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -12,7 +12,7 @@ defmodule Absinthe.Plug.GraphiQL do
   """
 
   require EEx
-  @graphiql_version "0.7.8"
+  @graphiql_version "0.9.3"
   EEx.function_from_file :defp, :graphiql_html, Path.join(__DIR__, "graphiql.html.eex"),
     [:graphiql_version, :query_string, :variables_string, :result_string]
 

--- a/lib/absinthe/plug/graphiql.html.eex
+++ b/lib/absinthe/plug/graphiql.html.eex
@@ -18,9 +18,9 @@ add "&raw" to the end of the URL within a browser.
     }
   </style>
   <link href="//cdn.jsdelivr.net/graphiql/<%= graphiql_version %>/graphiql.css" rel="stylesheet" />
-  <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.3.0/react.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.3.0/react-dom.min.js"></script>
+  <script src="//cdn.jsdelivr.net/fetch/1.1.0/fetch.min.js"></script>
+  <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+  <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
   <script src="//cdn.jsdelivr.net/graphiql/<%= graphiql_version %>/graphiql.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
This change also updates its dependencies (fetch, react, react-dom) to
their latest versions, as well.

GraphiQL changelog: https://github.com/graphql/graphiql/releases