### PR TITLE
update cdn to working fetch polyfill

### DIFF
--- a/lib/absinthe/plug/graphiql.html.eex
+++ b/lib/absinthe/plug/graphiql.html.eex
@@ -18,7 +18,7 @@ add "&raw" to the end of the URL within a browser.
     }
   </style>
   <link href="//cdn.jsdelivr.net/graphiql/<%= graphiql_version %>/graphiql.css" rel="stylesheet" />
-  <script src="//cdn.jsdelivr.net/fetch/1.1.0/fetch.min.js"></script>
+  <script src="//cdn.jsdelivr.net/fetch/2.0.1/fetch.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
   <script src="//cdn.jsdelivr.net/graphiql/<%= graphiql_version %>/graphiql.min.js"></script>


### PR DESCRIPTION
Looks like the v1.1.0 has been pulled from the cdn.  Updated to the newer version.  all test still pass and fixes issue in browsers not supporting fetch.