### PR TITLE
[v1.3] Better support for logging, variable filtering

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -197,6 +197,7 @@ defmodule Absinthe.Plug do
 
   @spec run_request(Absinthe.Plug.Request.t, Plug.Conn.t) :: {Plug.Conn.t, any}
   defp run_request(request, conn) do
+    Absinthe.Plug.Request.log(request)
     case Absinthe.Pipeline.run(request.document, Absinthe.Plug.DocumentProvider.pipeline(request)) do
       {:ok, result, _} ->
         {conn, {:ok, result}}

--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -88,6 +88,7 @@ defmodule Absinthe.Plug.GraphiQL do
          {:process, request} <- select_mode(request),
          {:ok, request} <- Absinthe.Plug.ensure_processable(request, config),
          pipeline <- Absinthe.Plug.DocumentProvider.pipeline(request),
+         :ok <- Absinthe.Plug.Request.log(request),
          {:ok, absinthe_result, _} <- Absinthe.Pipeline.run(request.document, pipeline) do
       {:ok, absinthe_result, request.variables, request.document || ""}
     end

--- a/lib/absinthe/plug/request.ex
+++ b/lib/absinthe/plug/request.ex
@@ -12,6 +12,7 @@ defmodule Absinthe.Plug.Request do
     :root_value,
     :variables,
     :raw_options,
+    :schema,
   ]
 
   defstruct [
@@ -23,6 +24,7 @@ defmodule Absinthe.Plug.Request do
     :root_value,
     :variables,
     :raw_options,
+    :schema,
     pipeline: [],
     document: nil,
     document_provider: nil,
@@ -42,6 +44,7 @@ defmodule Absinthe.Plug.Request do
     document_provider_key: any,
     pipeline: Absinthe.Pipeline.t,
     raw_options: Keyword.t,
+    schema: Absinthe.Schema.t,
   }
 
   @spec parse(Plug.Conn.t, map) :: {:ok, t} | {:input_error, String.t}
@@ -61,6 +64,7 @@ defmodule Absinthe.Plug.Request do
         params: params,
         raw_options: config.raw_options,
         root_value: root_value,
+        schema: config.schema_mod,
         variables: variables,
       }
       |> add_pipeline(conn, config)
@@ -228,6 +232,21 @@ defmodule Absinthe.Plug.Request do
       |> Keyword.new
       |> Keyword.split([:raw_options])
     Keyword.merge(opts, with_raw_options[:raw_options])
+  end
+
+  #
+  # LOGGING
+  #
+
+  @doc false
+  @spec log(t, Logger.level) :: :ok
+  def log(request, level \\ :debug) do
+    Absinthe.Logger.log_run(:debug, {
+      request.document,
+      request.schema,
+      request.pipeline,
+      to_pipeline_opts(request),
+    })
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Absinthe.Plug.Mixfile do
   defp deps do
     [
       {:plug, "~> 1.3.2 or ~> 1.4"},
-      {:absinthe, "~> 1.2.6"},
+      {:absinthe, github: "absinthe-graphql/absinthe", ref: "next"},
       {:poison, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.14.0", only: :dev},
       {:earmark, "~> 1.1.0", only: :dev},


### PR DESCRIPTION
This wires in request logging into the new `Absinthe.Logger` added in Absinthe's `next` branch, and supports variable filtering.

This should resolve #20 and #21.

Example output:

```
[debug] ABSINTHE schema=MyApp.Web.Schema variables=%{"calculatedEndDate" => "2017-03-05", "calculatedStartDate" => "2016-12-05", "token" => "[FILTERED]"}
---
query SomeQuery(ID!, $calculatedStartDate: Date, $calculatedEndDate: Date, $token: String!) {
  ...
}
---
```

- [x] Only one item is left to add; support for turning off request logging entirely, so that this will supercede #58 as well. I'll do that in the morning.