### PR TITLE
Fix empty document handling (:no_query_message)

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -174,8 +174,8 @@ defmodule Absinthe.Plug do
   @doc false
   @spec ensure_processable(Absinthe.Plug.Request.t, map) :: {:ok, Absinthe.Plug.Request.t} | {:input_error, String.t}
   def ensure_processable(request, config) do
-    with {:ok, request} <- ensure_document_provider(request) do
-      ensure_document(request, config)
+    with {:ok, request} <- ensure_document(request, config) do
+      ensure_document_provider(request)
     end
   end
 

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -133,6 +133,17 @@ defmodule Absinthe.PlugTest do
   }
   """
 
+  test "empty document returns :no_query_message" do
+    opts = Absinthe.Plug.init(schema: TestSchema)
+
+    assert %{status: 400, resp_body: resp_body} = conn(:get, "/", query: "")
+    |> put_req_header("content-type", "application/graphql")
+    |> plug_parser
+    |> Absinthe.Plug.call(opts)
+
+    assert resp_body == opts[:no_query_message]
+  end
+
   test "document with error returns validation errors" do
     opts = Absinthe.Plug.init(schema: TestSchema)
 


### PR DESCRIPTION
Previously, `:no_query_message` wasn't being returned for empty documents.
Instead, we'd get the "No document provider ..." response instead. We
prefer the former in this case because it's more intuitive.

This switches the order of checks within `ensure_processable/2` to inspect
the document before the document provider, restoring the previous "empty
document" response.