### PR TITLE
Implement `default_headers` option for Absinthe.Plug.GraphiQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,8 @@ end
 ```elixir
 def deps do
   [
-<<<<<<< HEAD
     ...,
-=======
     {:absinthe_plug, "~> 1.2.3"},
->>>>>>> master
     {:poison, "~> 1.3.0"}
   ]
 end

--- a/lib/absinthe/plug/graphiql_workspace.html.eex
+++ b/lib/absinthe/plug/graphiql_workspace.html.eex
@@ -28,7 +28,8 @@ add "&raw" to the end of the URL within a browser.
     var config = new graphiqlWorkspace.AppConfig("graphiql", {
       defaultUrl: window.location.origin + window.location.pathname,
       defaultQuery: '<%= query_string %>',
-      defaultVariables: '<%= variables_string %>'
+      defaultVariables: '<%= variables_string %>',
+      defaultHeaders: <%= default_headers %>
     });
 
     ReactDOM.render(


### PR DESCRIPTION
Implement `default_headers` option for [Absinthe.Plug.GraphiQL (#76)](https://github.com/absinthe-graphql/absinthe_plug/issues/76)

--- 

```elixir
forward "/graphiql",
  Absinthe.Plug.GraphiQL,
  schema: MyApp.Schema,
  default_headers: {__MODULE__, :graphiql_headers}

def graphiql_headers do
  %{
    "X-CSRF-Token" => Plug.CSRFProtection.get_csrf_token(),
    "X-Foo" => "Bar"
  }
end
```

![screen shot 2017-04-21 at 12 56 02 am](https://cloud.githubusercontent.com/assets/30173/25269410/5892f8e0-2631-11e7-9e1c-894fbccdd0ee.png)