### PR TITLE
Implement `default_url` option for Absinthe.Plug.GraphiQL

### DIFF
--- a/lib/absinthe/plug/graphiql_workspace.html.eex
+++ b/lib/absinthe/plug/graphiql_workspace.html.eex
@@ -10,9 +10,9 @@ add "&raw" to the end of the URL within a browser.
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  
+
   <title>GraphiQL Workspace</title>
-  
+
   <link rel="stylesheet" media="screen" href="//maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
   <link rel="stylesheet" media="screen" href="//cdnjs.cloudflare.com/ajax/libs/graphiql/0.9.3/graphiql.min.css">
   <link rel="stylesheet" media="screen" href="//unpkg.com/graphiql-workspace@<%= graphiql_workspace_version %>/graphiql-workspace.css">
@@ -23,10 +23,10 @@ add "&raw" to the end of the URL within a browser.
 </head>
 <body>
   <div id="workspace" class="graphiql-workspace"></div>
-  
+
   <script type="text/javascript">
     var config = new graphiqlWorkspace.AppConfig("graphiql", {
-      defaultUrl: window.location.origin + window.location.pathname,
+      defaultUrl: <%= default_url %>,
       defaultQuery: '<%= query_string %>',
       defaultVariables: '<%= variables_string %>',
       defaultHeaders: <%= default_headers %>

--- a/test/lib/absinthe/graphiql_test.exs
+++ b/test/lib/absinthe/graphiql_test.exs
@@ -40,6 +40,32 @@ defmodule Absinthe.Plug.GraphiQLTest do
     assert body |> String.contains?("defaultHeaders: " <> header_json)
   end
 
+  test "default_url option works" do
+    opts = Absinthe.Plug.GraphiQL.init(schema: TestSchema,
+      default_url: graphiql_default_url())
+
+    assert %{status: status, resp_body: body} = conn(:get, "/")
+    |> plug_parser
+    |> put_req_header("accept", "text/html")
+    |> Absinthe.Plug.GraphiQL.call(opts)
+
+    assert 200 == status
+    assert String.contains?(body, "defaultUrl: '#{graphiql_default_url()}'")
+  end
+
+  test "default_url unspecified" do
+    opts = Absinthe.Plug.GraphiQL.init(schema: TestSchema)
+
+    assert %{status: status, resp_body: body} = conn(:get, "/")
+    |> plug_parser
+    |> put_req_header("accept", "text/html")
+    |> Absinthe.Plug.GraphiQL.call(opts)
+
+    assert 200 == status
+    assert String.contains?(body,
+      "defaultUrl: window.location.origin + window.location.pathname")
+  end
+
   defp plug_parser(conn) do
     opts = Plug.Parsers.init(
       parsers: [:urlencoded, :multipart, :json],
@@ -54,5 +80,9 @@ defmodule Absinthe.Plug.GraphiQLTest do
       "Authorization" => "Basic Zm9vOmJhcg==",
       "X-CSRF-Token" => "foobarbaz"
     }
+  end
+
+  def graphiql_default_url do
+    "https://api.foobarbaz.test"
   end
 end


### PR DESCRIPTION
Hey! We recently needed to change this setting, but couldn't find a better way - so here's a PR for it.

Usage:
```
forward "/graphiql",
  Absinthe.Plug.GraphiQL,
  schema: MyApp.Schema,
  default_url: "https://my.defaulturl.com/foobarbaz"
```