### PR TITLE
Fixed Elixir 1.5 warnings

### DIFF
--- a/lib/absinthe/plug/graphiql.html.eex
+++ b/lib/absinthe/plug/graphiql.html.eex
@@ -26,7 +26,7 @@ add "&raw" to the end of the URL within a browser.
     <script src="<%= assets["graphiql-subscriptions-fetcher/browser/client.js"] %>"></script>
     <script src="<%= assets["phoenix.js"] %>"></script>
     <script src="<%= assets["absinthe-phoenix.js"] %>"></script>
-  <%= end %>
+  <% end %>
 </head>
 <body>
 
@@ -115,7 +115,7 @@ add "&raw" to the end of the URL within a browser.
         .catch(function (e) { console.error(`Couldn't connect`, e) });
       var graphQLFetcher = window.GraphiQLSubscriptionsFetcher.graphQLFetcher(client, graphQLFetcher);
 
-    <%= end %>
+    <% end %>
     // When the query and variables string is edited, update the URL bar so
     // that it can be easily shared.
     function onEditQuery(newQuery) {


### PR DESCRIPTION
```
==> absinthe_plug
Compiling 15 files (.ex)
warning: unexpected beginning of EEx tag "<%=" on end of expression "<%= end %>", please remove "=" accordingly
  lib/absinthe/plug/graphiql.html.eex:29

warning: unexpected beginning of EEx tag "<%=" on end of expression "<%= end %>", please remove "=" accordingly
  lib/absinthe/plug/graphiql.html.eex:118

Generated absinthe_plug app
```