### PR TITLE
Provide a public API for setting the context

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -182,6 +182,23 @@ defmodule Absinthe.Plug do
     end
   end
 
+  @doc """
+  Sets the options for a given GraphQL document execution.
+
+  ## Examples
+
+      iex> Absinthe.Plug.put_options(conn, context: %{current_user: user})
+      %Plug.Conn{}
+  """
+  @spec put_options(Plug.Conn.t, Keyword.t) :: Plug.Conn.t
+  def put_options(%Plug.Conn{private: %{absinthe: absinthe}} = conn, opts) do
+    opts = Map.merge(absinthe, Enum.into(opts, %{}))
+    Plug.Conn.put_private(conn, :absinthe, opts)
+  end
+  def put_options(conn, opts) do
+    Plug.Conn.put_private(conn, :absinthe, Enum.into(opts, %{}))
+  end
+
   @doc false
   @spec execute(Plug.Conn.t, map) :: {Plug.Conn.t, any}
   def execute(conn, config) do


### PR DESCRIPTION
Currently the way to set the absinthe context is a bit odd for users as it requires them to use Plug's `private` field directly. The `private` field is really only supposed to be used by libraries and frameworks:

https://github.com/elixir-plug/plug/blob/master/lib/plug/conn.ex#L86-L91

I think it would be more appropriate to provide a public function for setting the context, something like:

```ex
Absinthe.Plug.set_context(conn, %{...})
```

What do you think?