### PR TITLE
Fix curl command double quotes escaping

### DIFF
--- a/lib/absinthe/plug/types.ex
+++ b/lib/absinthe/plug/types.ex
@@ -37,7 +37,7 @@ defmodule Absinthe.Plug.Types do
 
   ```shell
   $ curl -X POST \\
-  -F query="{mutation uploadFile(users: \"users_csv\", metadata: \"metadata_json\")" \\
+  -F query="{mutation uploadFile(users: \\"users_csv\\", metadata: \\"metadata_json\\")" \\
   -F users_csv=@users.csv \\
   -F metadata_json=@metadata.json \\
   localhost:4000/graphql


### PR DESCRIPTION
It is a small doc fix but it is good to have examples that works. ;)