### PR TITLE
Changed documentation to use ~> 1.0.0 plug forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ forward "/api",
 
 For more information, see the API documentation for `Absinthe.Plug`.
 
+### Phoenix.Router
+
+If you are using [Phoenix.Router](https://hexdocs.pm/phoenix/Phoenix.Router.html), `forward` expects different arguments:
+
+#### Plug.Router
+
+```elixir
+forward "/graphiql",
+  to: Absinthe.Plug.GraphiQL,
+  init_opts: [
+    schema: MyApp.Schema,
+    interface: :simple
+  ]
+```
+
+#### Phoenix.Router
+
+```elixir
+forward "/graphiql",
+  Absinthe.Plug.GraphiQL,
+  schema: MyApp.Schema,
+  interface: :simple
+```
+
+For more information see [Phoenix.Router.forward/4](https://hexdocs.pm/phoenix/Phoenix.Router.html#forward/4).
+
+
 ## GraphiQL
 
 To add support for a GraphiQL interface, add a configuration for

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ plug Plug.Parsers,
   pass: ["*/*"],
   json_decoder: Poison
 
-forward "/api", Absinthe.Plug,
-  schema: MyApp.Schema
+forward "/api",
+  to: Absinthe.Plug,
+  init_opts: [schema: MyApp.Schema]
 ```
 
 For more information, see the API documentation for `Absinthe.Plug`.
@@ -75,8 +76,8 @@ To add support for a GraphiQL interface, add a configuration for
 
 ```elixir
 forward "/graphiql",
-  Absinthe.Plug.GraphiQL,
-  schema: MyApp.Schema,
+  to: Absinthe.Plug.GraphiQL,
+  init_opts: [schema: MyApp.Schema]
 ```
 
 See the API documentation for `Absinthe.Plug.GraphiQL` for more information.

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -22,8 +22,9 @@ defmodule Absinthe.Plug do
         pass: ["*/*"],
         json_decoder: Poison
 
-      forward "/api", Absinthe.Plug,
-        schema: MyApp.Schema
+      forward "/api",
+        to: Absinthe.Plug,
+        init_opts: [schema: MyApp.Schema]
 
   See the documentation on `Absinthe.Plug.init/1` and the `Absinthe.Plug.opts`
   type for information on the available options.
@@ -31,9 +32,9 @@ defmodule Absinthe.Plug do
   To add support for a GraphiQL interface, add a configuration for
   `Absinthe.Plug.GraphiQL`:
 
-      forward "/graphiql",
-        Absinthe.Plug.GraphiQL,
-        schema: MyApp.Schema,
+    forward "/graphiql",
+      to: Absinthe.Plug.GraphiQL,
+      init_opts: [schema: MyApp.Schema]
 
   ## Included GraphQL Types
 

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -36,6 +36,30 @@ defmodule Absinthe.Plug do
       to: Absinthe.Plug.GraphiQL,
       init_opts: [schema: MyApp.Schema]
 
+  For more information, see the API documentation for `Absinthe.Plug`.
+
+  ### Phoenix.Router
+
+  If you are using [Phoenix.Router](https://hexdocs.pm/phoenix/Phoenix.Router.html), `forward` expects different arguments:
+
+  #### Plug.Router
+
+      forward "/graphiql",
+        to: Absinthe.Plug.GraphiQL,
+        init_opts: [
+          schema: MyApp.Schema,
+          interface: :simple
+        ]
+
+  #### Phoenix.Router
+
+      forward "/graphiql",
+        Absinthe.Plug.GraphiQL,
+         schema: MyApp.Schema,
+         interface: :simple
+
+  For more information see [Phoenix.Router.forward/4](https://hexdocs.pm/phoenix/Phoenix.Router.html#forward/4).
+
   ## Included GraphQL Types
 
   This package includes additional types for use in Absinthe GraphQL schema and

--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -9,17 +9,19 @@ defmodule Absinthe.Plug.GraphiQL do
 
       if Mix.env == :dev do
         forward "/graphiql",
-          Absinthe.Plug.GraphiQL,
-          schema: MyApp.Schema
+          to: Absinthe.Plug.GraphiQL,
+          init_opts: [schema: MyApp.Schema]
       end
 
   Use the "simple" interface (original GraphiQL) instead:
 
       if Mix.env == :dev do
         forward "/graphiql",
-          Absinthe.Plug.GraphiQL,
-          schema: MyApp.Schema,
-          interface: :simple
+          to: Absinthe.Plug.GraphiQL,
+          init_opts: [
+            schema: MyApp.Schema,
+            interface: :simple
+          ]
 
   ## Interface Selection
 
@@ -36,9 +38,11 @@ defmodule Absinthe.Plug.GraphiQL do
   Note that you may have to clean up your existing workspace by clicking the trashcan icon in order to see the newly set default headers.
 
       forward "/graphiql",
-        Absinthe.Plug.GraphiQL,
-        schema: MyApp.Schema,
-        default_headers: {__MODULE__, :graphiql_headers}
+        to: Absinthe.Plug.GraphiQL,
+        init_opts: [
+          schema: MyApp.Schema,
+          default_headers: {__MODULE__, :graphiql_headers}
+        ]
 
       def graphiql_headers do
         %{
@@ -52,9 +56,11 @@ defmodule Absinthe.Plug.GraphiQL do
   You can also optionally set the default URL to be used for sending the queries to. This only applies to the advanced interface (GraphiQL Workspace).
 
       forward "/graphiql",
-        Absinthe.Plug.GraphiQL,
-        schema: MyApp.Schema,
-        default_url: "https://api.mydomain.com/graphql"
+        to: Absinthe.Plug.GraphiQL,
+        init_opts: [
+          schema: MyApp.Schema,
+          default_url: "https://api.mydomain.com/graphql"
+        ]
   """
 
   require EEx


### PR DESCRIPTION
I believe the `forward` examples in the documentation uses Phoenix's modified version which has a different API. Since this project has no mention of Phoenix, I believe it makes sense to reference the plug 1.0 API.