### PR TITLE
Integration with absinthe socket

### DIFF
--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -95,6 +95,9 @@ defmodule Absinthe.Plug.GraphiQL do
   EEx.function_from_file :defp, :graphiql_workspace_html, Path.join(@graphiql_template_path, "graphiql_workspace.html.eex"),
     [:query_string, :variables_string, :default_headers, :default_url, :socket_url, :assets]
 
+  EEx.function_from_file :defp, :graphiql_playground_html, Path.join(@graphiql_template_path, "graphiql_playground.html.eex"),
+  [:query_string, :variables_string, :default_headers, :default_url, :socket_url, :assets]
+
   @behaviour Plug
 
   import Plug.Conn
@@ -105,7 +108,7 @@ defmodule Absinthe.Plug.GraphiQL do
     path: binary,
     context: map,
     json_codec: atom | {atom, Keyword.t},
-    interface: :advanced | :simple,
+    interface: :playground | :advanced | :simple,
     default_headers: {module, atom},
     default_url: binary,
     assets: Keyword.t,
@@ -307,6 +310,16 @@ defmodule Absinthe.Plug.GraphiQL do
       |> with_socket_url(conn, opts)
 
     graphiql_workspace_html(
+      opts[:query], opts[:var_string], opts[:default_headers],
+      default_url(opts[:default_url]), opts[:socket_url], opts[:assets]
+    )
+    |> rendered(conn)
+  end
+  defp render_interface(conn, :playground, opts) do
+    opts = Map.merge(@render_defaults, opts)
+      |> with_socket_url(conn, opts)
+
+    graphiql_playground_html(
       opts[:query], opts[:var_string], opts[:default_headers],
       default_url(opts[:default_url]), opts[:socket_url], opts[:assets]
     )

--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -34,12 +34,9 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
       "graphiql.css",
       {"graphiql.min.js", "graphiql.js"},
     ]},
-    {"graphiql-workspace", "1.1.3", [
+    {"@absinthe/graphiql-workspace", "1.1.5", [
       "graphiql-workspace.css",
       {"graphiql-workspace.min.js", "graphiql-workspace.js"}
-    ]},
-    {"graphiql-subscriptions-fetcher", "0.0.2", [
-      {"browser/client.js", "graphiql-subscriptions-fetcher.js"},
     ]},
     {"@absinthe/socket-graphiql", "0.1.1", [
       {"compat/umd/index.js", "socket-graphiql.js"},

--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -30,7 +30,7 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
       {"dist/fonts/glyphicons-halflings-regular.svg", "fonts/glyphicons-halflings-regular.svg"},
       {"dist/css/bootstrap.min.css", "css/bootstrap.css"},
     ]},
-    {"graphiql", "0.11.3", [
+    {"graphiql", "0.11.10", [
       "graphiql.css",
       {"graphiql.min.js", "graphiql.js"},
     ]},
@@ -41,11 +41,8 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
     {"graphiql-subscriptions-fetcher", "0.0.2", [
       {"browser/client.js", "graphiql-subscriptions-fetcher.js"},
     ]},
-    {"phoenix", "1.3.0", [
-      {"priv/static/phoenix.min.js", "phoenix.js"},
-    ]},
-    {"absinthe-phoenix", "0.1.1", [
-      {"browser/index.min.js", "absinthe-phoenix.js"},
+    {"@absinthe/socket-graphiql", "0.1.1", [
+      {"compat/umd/index.js", "socket-graphiql.js"},
     ]},
   ]
 

--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -38,6 +38,10 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
       "graphiql-workspace.css",
       {"graphiql-workspace.min.js", "graphiql-workspace.js"}
     ]},
+    {"@absinthe/graphql-playground", "1.1.3", [
+      {"build/static/css/middleware.css", "playground.css"},
+      {"build/static/js/middleware.js", "playground.js"}
+    ]},
     {"@absinthe/socket-graphiql", "0.1.1", [
       {"compat/umd/index.js", "socket-graphiql.js"},
     ]},

--- a/lib/absinthe/plug/graphiql/graphiql.html.eex
+++ b/lib/absinthe/plug/graphiql/graphiql.html.eex
@@ -22,11 +22,7 @@ add "&raw" to the end of the URL within a browser.
   <script src="<%= assets["react/react.js"] %>"></script>
   <script src="<%= assets["react-dom/react-dom.js"] %>"></script>
   <script src="<%= assets["graphiql/graphiql.js"] %>"></script>
-  <%= if socket_url do %>
-    <script src="<%= assets["graphiql-subscriptions-fetcher/graphiql-subscriptions-fetcher.js"] %>"></script>
-    <script src="<%= assets["phoenix/phoenix.js"] %>"></script>
-    <script src="<%= assets["absinthe-phoenix/absinthe-phoenix.js"] %>"></script>
-  <% end %>
+  <script src="<%= assets["@absinthe/socket-graphiql/socket-graphiql.js"] %>"></script>
 </head>
 <body>
 
@@ -59,63 +55,14 @@ add "&raw" to the end of the URL within a browser.
         otherParams[k] = parameters[k];
       }
     }
+
     var fetchURL = locationQuery(otherParams);
-    // Defines a GraphQL fetcher using the fetch API.
-    function graphQLFetcher(graphQLParams) {
-      return fetch(fetchURL, {
-        method: 'post',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(graphQLParams),
-        credentials: 'include',
-      }).then(function (response) {
-        return response.text();
-      }).then(function (responseBody) {
-        try {
-          return JSON.parse(responseBody);
-        } catch (error) {
-          return responseBody;
-        }
-      });
-    }
+    var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    var wsUrl = <%= if socket_url do %> <%= socket_url %><% else %>'ws://localhost:4000/socket'<% end %>;
 
-    <%= if socket_url do %>
+    var subscriptionsClient = new AbsintheSocketGraphiql.SubscriptionsClient(wsUrl, {});
+    var fetcher = AbsintheSocketGraphiql.createFetcher(fetchURL, subscriptionsClient, 'Your subscription data will appear here after server publication!');
 
-      var protocol;
-      if (window.location.protocol === "https:") {
-        protocol = "wss:"
-      } else {
-        protocol = "ws:"
-      }
-
-      var client = new AbsinthePhoenix.default(<%= socket_url %>);
-      // stop doing this eventually
-      var serverSubscriptionId;
-      client.old_subscribe = client.subscribe
-      client.subscribe = function(doc, cb) {
-        this.old_subscribe(doc, cb).then(function(resp) { serverSubscriptionId = resp.subscriptionId});
-        // mock client generated subscription id
-        return "1"
-      };
-
-      client.old_unsubscribe = client.unsubscribe
-      client.unsubscribe = function(clientSubscriptionId) {
-        this.old_unsubscribe(serverSubscriptionId);
-      };
-
-      client.dispatchSubscriptionCallback = function(resp, cb) {
-        // GraphiQL wants the data as a string
-        cb(JSON.stringify(resp.result, null, 2));
-      }
-
-      client.connect()
-        .then(function () { console.log('Connected.'); })
-        .catch(function (e) { console.error(`Couldn't connect`, e) });
-      var graphQLFetcher = window.GraphiQLSubscriptionsFetcher.graphQLFetcher(client, graphQLFetcher);
-
-    <% end %>
     // When the query and variables string is edited, update the URL bar so
     // that it can be easily shared.
     function onEditQuery(newQuery) {
@@ -132,7 +79,7 @@ add "&raw" to the end of the URL within a browser.
     // Render <GraphiQL /> into the body.
     ReactDOM.render(
       React.createElement(GraphiQL, {
-        fetcher: graphQLFetcher,
+        fetcher,
         onEditQuery: onEditQuery,
         onEditVariables: onEditVariables,
         query: '<%= query_string %>',

--- a/lib/absinthe/plug/graphiql/graphiql_playground.html.eex
+++ b/lib/absinthe/plug/graphiql/graphiql_playground.html.eex
@@ -1,0 +1,67 @@
+<!--
+The request to this GraphQL server provided the header "Accept: text/html"
+and as a result has been presented GraphiQL - an in-browser IDE for
+exploring GraphQL.
+If you wish to receive JSON, provide the header "Accept: application/json" or
+add "&raw" to the end of the URL within a browser.
+-->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="shortcut icon" href="https://graphcool-playground.netlify.com/favicon.png">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,700" rel="stylesheet">
+  <title>Playground</title>
+  <link rel="stylesheet" media="screen" href="<%= assets["@absinthe/graphql-playground/playground.css"] %>">
+</head>
+
+<body>
+  <div id="root">
+    <style>
+      body {
+        background-color: #172a3a;
+        font-family: Open Sans, sans-serif;
+        height: 90vh
+      }
+
+      #root {
+        height: 100%;
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center
+      }
+
+      .loading {
+        font-size: 32px;
+        font-weight: 200;
+        color: rgba(255, 255, 255, .6);
+        margin-left: 20px
+      }
+
+      img {
+        width: 78px;
+        height: 78px
+      }
+
+      .title {
+        font-weight: 400
+      }
+    </style>
+    <div class="loading">Loading
+      <span class="title">GraphQL Playground</span>
+    </div>
+  </div>
+  <script>
+    var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    var options = {
+      subscriptionEndpoint: <%= if socket_url do %> <%= socket_url %><% else %>'ws://localhost:4000/socket'<% end %>
+    };
+    window.addEventListener("load", function (n) { GraphQLPlayground.init(document.getElementById("root"),options) })
+  </script>
+  <script type="text/javascript" src="<%= assets["@absinthe/graphql-playground/playground.js"] %>"></script>
+</body>
+
+</html

--- a/lib/absinthe/plug/graphiql/graphiql_workspace.html.eex
+++ b/lib/absinthe/plug/graphiql/graphiql_workspace.html.eex
@@ -15,53 +15,22 @@ add "&raw" to the end of the URL within a browser.
 
   <link rel="stylesheet" media="screen" href="<%= assets["bootstrap/css/bootstrap.css"] %>">
   <link rel="stylesheet" media="screen" href="<%= assets["graphiql/graphiql.css"] %>">
-  <link rel="stylesheet" media="screen" href="<%= assets["graphiql-workspace/graphiql-workspace.css"] %>">
+  <link rel="stylesheet" media="screen" href="<%= assets["@absinthe/graphiql-workspace/graphiql-workspace.css"] %>">
 
   <script src="<%= assets["react/react.js"] %>"></script>
   <script src="<%= assets["react-dom/react-dom.js"] %>"></script>
-  <script src="<%= assets["graphiql-workspace/graphiql-workspace.js"] %>"></script>
-  <%= if socket_url do %>
-    <script src="<%= assets["phoenix/phoenix.js"] %>"></script>
-    <script src="<%= assets["absinthe-phoenix/absinthe-phoenix.js"] %>"></script>
-  <% end %>
+  <script src="<%= assets["@absinthe/graphiql-workspace/graphiql-workspace.js"] %>"></script>
+  <script src="<%= assets["@absinthe/socket-graphiql/socket-graphiql.js"] %>"></script>
 </head>
 <body>
   <div id="workspace" class="graphiql-workspace"></div>
 
   <script type="text/javascript">
-    <%= if socket_url do %>
-      function absintheSubscriptionsClientBuilder(url, connectionParams) {
-        var client = new AbsinthePhoenix.default(url, {params: connectionParams});
+    function absintheSubscriptionsClientBuilder(url, connectionParams) {
+      return new AbsintheSocketGraphiql.SubscriptionsClient(url, {params: connectionParams});
+    }
 
-        // stop doing this eventually
-        var serverSubscriptionId;
-        client.old_subscribe = client.subscribe
-        client.subscribe = function(doc, cb) {
-          this.old_subscribe(doc, cb).then(function(resp) { serverSubscriptionId = resp.subscriptionId});
-          // mock client generated subscription id
-          return "1"
-        };
-
-        client.old_unsubscribe = client.unsubscribe
-        client.unsubscribe = function(clientSubscriptionId) {
-          this.old_unsubscribe(serverSubscriptionId);
-        };
-
-        client.dispatchSubscriptionCallback = function(resp, cb) {
-          // GraphiQL wants the data as a string
-          cb(JSON.stringify(resp.result, null, 2));
-        }
-
-        client.connect()
-          .then(function () { console.log('Connected.'); })
-          .catch(function (e) { console.error(`Couldn't connect`, e) });
-
-        return client;
-      }
-
-      var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    <% end %>
-
+    var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     var config = new graphiqlWorkspace.AppConfig("graphiql", {
       defaultUrl: <%= default_url %>,
       <%= if socket_url do %>


### PR DESCRIPTION
- Integration with Graphiql (latest version) and Graphiql Workspace is done 🚀 
- Graphql Playground is now supported as well 🚀 🎉 

Passing http headers to subscriptions works in both workspace and playground. I even tweaked playground to properly reset the socket when the http headers are updated.