### PR TITLE
ensure the socket URL is a string

### DIFF
--- a/lib/absinthe/plug/graphiql/graphiql_playground.html.eex
+++ b/lib/absinthe/plug/graphiql/graphiql_playground.html.eex
@@ -10,7 +10,7 @@ add "&raw" to the end of the URL within a browser.
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  
+
   <title>GraphiQL Playground</title>
 
   <link href="<%= assets["typeface-open-sans/index.css"] %>" rel="stylesheet">
@@ -57,7 +57,7 @@ add "&raw" to the end of the URL within a browser.
   <script>
     var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     var options = {
-      subscriptionEndpoint: <%= if socket_url do %> <%= socket_url %><% else %>'ws://localhost:4000/socket'<% end %>
+      subscriptionEndpoint: <%= if socket_url do %>'<%= socket_url %>'<% else %>'ws://localhost:4000/socket'<% end %>
     };
     window.addEventListener("load", function (n) { GraphQLPlayground.init(document.getElementById("root"), options) })
   </script>


### PR DESCRIPTION
When I tried to add a custom websocket URL, I ended up seeing this error in my javascript console: 

```
Uncaught SyntaxError: Unexpected token :
```

when I click through the error, it looks like the websocket URL isn't a string. 

<img width="474" alt="screen shot 2017-12-06 at 3 23 50 pm" src="https://user-images.githubusercontent.com/6731804/33690678-8ea91898-da99-11e7-838e-b707be688219.png">

I actually found this out when working on #131, but in the interest of simple isolated fixes I pulled it into a separate PR. If you decide to merge #131 right away then this fix doesn't really matter. 

/cc @bruce @benwilson512 @tlvenn 