### PR TITLE
Enquote socket url to prevent it from breaking js

### DIFF
--- a/lib/absinthe/plug/graphiql/graphiql_workspace.html.eex
+++ b/lib/absinthe/plug/graphiql/graphiql_workspace.html.eex
@@ -32,7 +32,7 @@ add "&raw" to the end of the URL within a browser.
     var config = new graphiqlWorkspace.AppConfig("graphiql", {
       defaultUrl: <%= default_url %>,
       <%= if socket_url do %>
-        defaultWebsocketUrl: <%= socket_url %>,
+        defaultWebsocketUrl: '<%= socket_url %>',
         subscriptionsClientBuilder: absintheSubscriptionsClientBuilder,
       <% end %>
       defaultQuery: '<%= query_string %>',


### PR DESCRIPTION
-`socket_url` is a string, so it will be templated literally into the template string
- We want it in quotes, so we have to put quotes around it.
- Fixes #135