### PR TITLE
fix code in doc block

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -32,9 +32,9 @@ defmodule Absinthe.Plug do
   To add support for a GraphiQL interface, add a configuration for
   `Absinthe.Plug.GraphiQL`:
 
-    forward "/graphiql",
-      to: Absinthe.Plug.GraphiQL,
-      init_opts: [schema: MyAppWeb.Schema]
+      forward "/graphiql",
+        to: Absinthe.Plug.GraphiQL,
+        init_opts: [schema: MyAppWeb.Schema]
 
   For more information, see the API documentation for `Absinthe.Plug`.
 


### PR DESCRIPTION
https://hexdocs.pm/absinthe_plug/Absinthe.Plug.html#module-usage showed a small layout quirk, where the first line wasn't included in the code block it belonged to. like this:

> To add support for a GraphiQL interface, add a configuration for Absinthe.Plug.GraphiQL:
> 
> forward “/graphiql”,
> 
>     to: Absinthe.Plug.GraphiQL,
>     init_opts: [schema: MyAppWeb.Schema]
> 
> For more information, see the API documentation for Absinthe.Plug.

prepending two white spaces for those lines fixed the issue. afterwards it looks like this:

> To add support for a GraphiQL interface, add a configuration for Absinthe.Plug.GraphiQL:
> 
>     forward “/graphiql”,
>       to: Absinthe.Plug.GraphiQL,
>       init_opts: [schema: MyAppWeb.Schema]
> 
> For more information, see the API documentation for Absinthe.Plug.