### PR TITLE
compile time warning on doc block

### DIFF
--- a/lib/absinthe/plug/document_provider/compiled.ex
+++ b/lib/absinthe/plug/document_provider/compiled.ex
@@ -42,7 +42,7 @@ defmodule Absinthe.Plug.DocumentProvider.Compiled do
 
       use Absinthe.Plug.DocumentProvider.Compiled, key_param: "lookup_key"
 
- ## Configuring
+  ## Configuring
 
   You need to configure `Absinthe.Plug` to use any document providers that you create.
   (Only `Absinthe.Plug.DocumentProviders.Default` is configured by default.)


### PR DESCRIPTION
the changed line was indented too little, causing a warning while compiling (at least on elixir 1.6.0):

> **warning**: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing `"""`. The following is forbidden:
> 
>     def text do
>       """
>     contents
>       """
>     end
> 
> Instead make sure the contents are indented as much as the heredoc closing:
> 
>     def text do
>       """
>       contents
>       """
>     end
> 
> The current heredoc line is indented too little
>   lib/absinthe/plug/document_provider/compiled.ex:45