### PR TITLE
update invalid link to phoenix guide

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -113,7 +113,7 @@ defmodule Absinthe.Plug do
   ## More Information
 
   For more on configuring `Absinthe.Plug` and how GraphQL requests are made,
-  see [the guide](http://absinthe-graphql.org/guides/plug-phoenix/) at
+  see [the guide](https://hexdocs.pm/absinthe/plug-phoenix.html) at
   <http://absinthe-graphql.org>.
 
   """


### PR DESCRIPTION
the provided link does result in a `404 Not Found`. I'm not entirely sure about the suggested link, but i was the best match from the list of available guides given the path we had before.