### PR TITLE
add required init function for Plug.Parser behaviour

### DIFF
--- a/lib/absinthe/plug/parser.ex
+++ b/lib/absinthe/plug/parser.ex
@@ -21,6 +21,9 @@ defmodule Absinthe.Plug.Parser do
   alias Plug.Conn
 
   @doc false
+  def init(opts), do: opts
+
+  @doc false
   def parse(conn, "application", "graphql", _headers, opts) do
     case Conn.read_body(conn, opts) do
       {:ok, body, conn} ->

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
-%{"absinthe": {:hex, :absinthe, "1.4.0", "f2261f4bf62dd03a5fc75472b6ebfaa262f7133386d759cb965067e633888b0c", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
-  "plug": {:hex, :plug, "1.3.4", "b4ef3a383f991bfa594552ded44934f2a9853407899d47ecc0481777fb1906f6", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"}}
+%{
+  "absinthe": {:hex, :absinthe, "1.4.9", "621d6105cec5f486cf6e52d9eef88871ed1beb855b89c30aec5015ad5c9dedf4", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
I noticed that after an update to plug `1.5.0` I was getting a compile-time warning like this

```
==> absinthe_plug
Compiling 18 files (.ex)
warning: function init/1 required by behaviour Plug.Parsers is not implemented (in module Absinthe.Plug.Parser)
  lib/absinthe/plug/parser.ex:1
```

It looks like this callback used to be optional, but is now required. I tested compiling under the current `mix.lock` and after a `mix deps update --all` to make sure it compiles cleanly under both.