### PR TITLE
Added checking conn state before sending resp.

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -239,35 +239,39 @@ defmodule Absinthe.Plug do
     config = update_config(conn, config)
     {conn, result} = conn |> execute(config)
 
-    case result do
-      {:input_error, msg} ->
-        conn
-        |> send_resp(400, msg)
+    if conn.state == :unset do
+      case result do
+        {:input_error, msg} ->
+          conn
+          |> send_resp(400, msg)
 
-      {:ok, %{"subscribed" => topic}} ->
-        conn
-        |> subscribe(topic, config)
+        {:ok, %{"subscribed" => topic}} ->
+          conn
+          |> subscribe(topic, config)
 
-      {:ok, %{data: _} = result} ->
-        conn
-        |> encode(200, result, config)
+        {:ok, %{data: _} = result} ->
+          conn
+          |> encode(200, result, config)
 
-      {:ok, %{errors: _} = result} ->
-        conn
-        |> encode(400, result, config)
+        {:ok, %{errors: _} = result} ->
+          conn
+          |> encode(400, result, config)
 
-      {:ok, result} when is_list(result) ->
-        conn
-        |> encode(200, result, config)
+        {:ok, result} when is_list(result) ->
+          conn
+          |> encode(200, result, config)
 
-      {:error, {:http_method, text}, _} ->
-        conn
-        |> send_resp(405, text)
+        {:error, {:http_method, text}, _} ->
+          conn
+          |> send_resp(405, text)
 
-      {:error, error, _} when is_binary(error) ->
-        conn
-        |> send_resp(500, error)
+        {:error, error, _} when is_binary(error) ->
+          conn
+          |> send_resp(500, error)
 
+      end
+    else
+      conn
     end
   end
 


### PR DESCRIPTION
This change is small, but it is very useful when you want to `send_resp` in before_send hook.

About my situation. 
I want to check authorization just before resolve function, because my app uses users permissions to allow/deny access to fields. So I use 
```elixir
    Absinthe.Plug.put_options(conn, context: %{ current_user: resource })
```
in plug before `Absinthe.Plug` and then (in `before_send`) I want to check that authorization is checked (I can forget to add auth checker middleware before resolve func) and passed (is user authorized and have required permissions) and **send 401 response with message** if authorization failed. But if I try to do it, I get `Plug.Conn.AlreadySentError` in `(absinthe_plug) lib/absinthe/plug.ex:471: Absinthe.Plug.encode/4` because absinthe_plug tries to send_resp second time.
Also I think that it can be useful in other situations.
Thanks