### PR TITLE
reproduce issue #151

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,25 +4,28 @@ defmodule Absinthe.Plug.Mixfile do
   @version "1.4.3"
 
   def project do
-    [app: :absinthe_plug,
-     version: @version,
-     elixir: "~> 1.3",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     elixirc_paths: elixirc_paths(Mix.env),
-     package: package(),
-     docs: [source_ref: "v#{@version}", main: "Absinthe.Plug"],
-     deps: deps()]
+    [
+      app: :absinthe_plug,
+      version: @version,
+      elixir: "~> 1.3",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      package: package(),
+      docs: [source_ref: "v#{@version}", main: "Absinthe.Plug"],
+      deps: deps()
+    ]
   end
 
   defp package do
-    [description: "Plug support for Absinthe, the GraphQL toolkit for Elixir",
-     files: ["lib", "mix.exs", "README*"],
-     maintainers: ["Ben Wilson", "Bruce Williams"],
-     licenses: ["MIT"],
-     links: %{
-       site: "http://absinthe-graphql.org",
-       github: "https://github.com/absinthe-graphql/absinthe_plug",
+    [
+      description: "Plug support for Absinthe, the GraphQL toolkit for Elixir",
+      files: ["lib", "mix.exs", "README*"],
+      maintainers: ["Ben Wilson", "Bruce Williams"],
+      licenses: ["MIT"],
+      links: %{
+        site: "http://absinthe-graphql.org",
+        github: "https://github.com/absinthe-graphql/absinthe_plug"
       }
     ]
   end
@@ -33,14 +36,15 @@ defmodule Absinthe.Plug.Mixfile do
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp deps do
     [
       {:plug, "~> 1.3.2 or ~> 1.4"},
-      {:absinthe, "~> 1.4"},
+      {:absinthe, git: "git@github.com:nitingupta910/absinthe.git", branch: "issue539"},
+      # {:absinthe, "~> 1.4"},
       {:poison, ">= 0.0.0", only: [:dev, :test]},
-      {:ex_doc, "~> 0.18.0", only: :dev},
+      {:ex_doc, "~> 0.18.0", only: :dev}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "absinthe": {:hex, :absinthe, "1.4.10", "9f8d0c34dfcfd0030d3a3f123c7501e99ab59651731387289dad5885047ebb2a", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "absinthe": {:git, "git@github.com:nitingupta910/absinthe.git", "5b88d87a57ac0c51015aa0452517533a0817df1e", [branch: "issue539"]},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -37,6 +37,17 @@ defmodule Absinthe.Plug.TestSchema do
         {:ok, arg_keys |> Enum.join(", ")}
       end
     end
+
+    field :user, :string do
+      resolve fn _, %{
+        context: %{
+          user: user
+        }
+      } ->
+        {:ok, user}
+      end
+    end
+
     field :item,
       type: :item,
       args: [


### PR DESCRIPTION
This pull request is to reproduce issue #151. It adds two tests -- the one using the default document provider passes but the one using LiteralDocuments provider fails. Below is output from mix test:

```
Absinthe.Plug.DocumentProvider.CompiledTest
  * test works using documents provided as literals (0.5ms)
  * test context passed correctly to resolvers with documents provided as literals (2.3ms)

  1) test context passed correctly to resolvers with documents provided as literals (Absinthe.Plug.DocumentProvider.CompiledTest)
     test/lib/absinthe/plug/document_provider/compiled_test.exs:72
     ** (FunctionClauseError) no function clause matching in anonymous fn/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1

     The following arguments were given to anonymous fn/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1:

         # 1
         %{}

         # 2
         #Absinthe.Resolution<[acc: %{Absinthe.Middleware.Async => false, Absinthe.Middleware.Batch => %{input: [], output: %{}}}, adapter: Absinthe.Adapter.LanguageConventions, arguments: %{}, context: %{}, definition: %Absinthe.Blueprint.Document.Field{alias: nil, argument_data: %{}, arguments: [], complexity: nil, directives: [], errors: [], flags: %{}, name: "user", schema_node: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :user, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 41}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :user, middleware: [{{Absinthe.Resolution, :call}, #Function<4.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "user", triggers: [], type: :string}, selections: [], source_location: %Absinthe.Blueprint.Document.SourceLocation{column: nil, line: 2}, type_conditions: []}, errors: [], extensions: %{}, fields_cache: "#fieldscache<...>", fragments: %{}, middleware: [], parent_type: %Absinthe.Type.Object{__private__: [], __reference__: %{identifier: :query, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 16}, module: Absinthe.Plug.TestSchema}, description: nil, field_imports: [], fields: %{complex: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :complex, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 62}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: 100, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :complex, middleware: [{{Absinthe.Resolution, :call}, #Function<2.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "complex", triggers: [], type: :string}, expensive: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :expensive, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 17}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: 1000, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :expensive, middleware: [{{Absinthe.Resolution, :call}, #Function<7.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "expensive", triggers: [], type: :integer}, field_on_root_value: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :field_on_root_value, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 60}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :field_on_root_value, middleware: [{Absinthe.Middleware.MapGet, :field_on_root_value}], name: "field_on_root_value", triggers: [], type: :string}, item: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :item, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 51}, module: Absinthe.Plug.TestSchema}, args: %{id: %Absinthe.Type.Argument{__reference__: %{identifier: :id, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 51}, module: Absinthe.Plug.TestSchema}, default_value: nil, deprecation: nil, description: nil, name: "id", type: %Absinthe.Type.NonNull{of_type: :id}}}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :item, middleware: [{Absinthe.Resolution, #Function<3.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "item", triggers: [], type: :item}, ping_counter: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :ping_counter, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 22}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :ping_counter, middleware: [{{Absinthe.Resolution, :call}, #Function<6.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "ping_counter", triggers: [], type: :integer}, upload_test: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :upload_test, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 30}, module: Absinthe.Plug.TestSchema}, args: %{auth: %Absinthe.Type.Argument{__reference__: %{identifier: :auth, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 33}, module: Absinthe.Plug.TestSchema}, default_value: nil, deprecation: nil, description: nil, name: "auth", type: :string}, file_a: %Absinthe.Type.Argument{__reference__: %{identifier: :file_a, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 31}, module: Absinthe.Plug.TestSchema}, default_value: nil, deprecation: nil, description: nil, name: "file_a", type: %Absinthe.Type.NonNull{of_type: :upload}}, file_b: %Absinthe.Type.Argument{__reference__: %{identifier: :file_b, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 32}, module: Absinthe.Plug.TestSchema}, default_value: nil, deprecation: nil, description: nil, name: "file_b", type: :upload}}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :upload_test, middleware: [{{Absinthe.Resolution, :call}, #Function<5.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "upload_test", triggers: [], type: :string}, user: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :user, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 41}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :user, middleware: [{{Absinthe.Resolution, :call}, #Function<4.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "user", triggers: [], type: :string}}, identifier: :query, interfaces: [], is_type_of: nil, name: "RootQueryType"}, path: [%Absinthe.Blueprint.Document.Field{alias: nil, argument_data: %{}, arguments: [], complexity: nil, directives: [], errors: [], flags: %{}, name: "user", schema_node: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :user, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 41}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :user, middleware: [{{Absinthe.Resolution, :call}, #Function<4.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "user", triggers: [], type: :string}, selections: [], source_location: %Absinthe.Blueprint.Document.SourceLocation{column: nil, line: 2}, type_conditions: []}, %Absinthe.Blueprint.Document.Operation{complexity: nil, current: true, directives: [], errors: [], flags: %{}, fragment_uses: [], name: "GetUser", provided_values: %{}, schema_node: %Absinthe.Type.Object{__private__: [], __reference__: %{identifier: :query, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 16}, module: Absinthe.Plug.TestSchema}, description: nil, field_imports: [], fields: %{complex: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :complex, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 62}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: 100, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :complex, middleware: [{{Absinthe.Resolution, :call}, #Function<2.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "complex", triggers: [], type: :string}, expensive: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :expensive, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 17}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: 1000, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :expensive, middleware: [{{Absinthe.Resolution, :call}, #Function<7.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "expensive", triggers: [], type: :integer}, field_on_root_value: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :field_on_root_value, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 60}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :field_on_root_value, middleware: [{Absinthe.Middleware.MapGet, :field_on_root_value}], name: "field_on_root_value", triggers: [], type: :string}, item: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :item, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 51}, module: Absinthe.Plug.TestSchema}, args: %{id: %Absinthe.Type.Argument{__reference__: %{identifier: :id, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 51}, module: Absinthe.Plug.TestSchema}, default_value: nil, deprecation: nil, description: nil, name: "id", type: %Absinthe.Type.NonNull{of_type: :id}}}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :item, middleware: [{Absinthe.Resolution, #Function<3.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "item", triggers: [], type: :item}, ping_counter: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :ping_counter, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 22}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :ping_counter, middleware: [{{Absinthe.Resolution, :call}, #Function<6.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "ping_counter", triggers: [], type: :integer}, upload_test: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :upload_test, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 30}, module: Absinthe.Plug.TestSchema}, args: %{auth: %Absinthe.Type.Argument{__reference__: %{identifier: :auth, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 33}, module: Absinthe.Plug.TestSchema}, default_value: nil, deprecation: nil, description: nil, name: "auth", type: :string}, file_a: %Absinthe.Type.Argument{__reference__: %{identifier: :file_a, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 31}, module: Absinthe.Plug.TestSchema}, default_value: nil, deprecation: nil, description: nil, name: "file_a", type: %Absinthe.Type.NonNull{of_type: :upload}}, file_b: %Absinthe.Type.Argument{__reference__: %{identifier: :file_b, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 32}, module: Absinthe.Plug.TestSchema}, default_value: nil, deprecation: nil, description: nil, name: "file_b", type: :upload}}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :upload_test, middleware: [{{Absinthe.Resolution, :call}, #Function<5.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "upload_test", triggers: [], type: :string}, user: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :user, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 41}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :user, middleware: [{{Absinthe.Resolution, :call}, #Function<4.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "user", triggers: [], type: :string}}, identifier: :query, interfaces: [], is_type_of: nil, name: "RootQueryType"}, selections: [%Absinthe.Blueprint.Document.Field{alias: nil, argument_data: %{}, arguments: [], complexity: nil, directives: [], errors: [], flags: %{}, name: "user", schema_node: %Absinthe.Type.Field{__private__: [], __reference__: %{identifier: :user, location: %{file: "/Users/ngupta/src/absinthe_plug/test/support/test_schema.ex", line: 41}, module: Absinthe.Plug.TestSchema}, args: %{}, complexity: nil, config: nil, default_value: nil, deprecation: nil, description: nil, identifier: :user, middleware: [{{Absinthe.Resolution, :call}, #Function<4.78707181/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1>}], name: "user", triggers: [], type: :string}, selections: [], source_location: %Absinthe.Blueprint.Document.SourceLocation{column: nil, line: 2}, type_conditions: []}], source_location: %Absinthe.Blueprint.Document.SourceLocation{column: nil, line: 1}, type: :query, variable_definitions: [], variable_uses: []}], private: %{}, root_value: %{}, schema: Absinthe.Plug.TestSchema, source: %{}, state: :unresolved, value: nil]>

     code: |> Absinthe.Plug.call(opts)
     stacktrace:
       (absinthe_plug) test/support/test_schema.ex:42: anonymous fn/2 in Absinthe.Plug.TestSchema.__absinthe_type__/1
       (absinthe) lib/absinthe/resolution.ex:206: Absinthe.Resolution.call/2
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:209: Absinthe.Phase.Document.Execution.Resolution.reduce_resolution/1
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:168: Absinthe.Phase.Document.Execution.Resolution.do_resolve_field/4
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:153: Absinthe.Phase.Document.Execution.Resolution.do_resolve_fields/6
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:72: Absinthe.Phase.Document.Execution.Resolution.walk_result/5
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:53: Absinthe.Phase.Document.Execution.Resolution.perform_resolution/3
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:24: Absinthe.Phase.Document.Execution.Resolution.resolve_current/3
       (absinthe) lib/absinthe/pipeline.ex:268: Absinthe.Pipeline.run_phase/3
       (absinthe_plug) lib/absinthe/plug.ex:414: Absinthe.Plug.run_query/4
       (absinthe_plug) lib/absinthe/plug.ex:240: Absinthe.Plug.call/2
       test/lib/absinthe/plug/document_provider/compiled_test.exs:79: (test)

  * test .get compiled (0.00ms)
  * test works using documents loaded from an extracted_queries.json (8.7ms)
  * test context passed correctly to resolvers with the default document provider (6.6ms)
  * test .get source (0.00ms)
```