### PR TITLE
Fix compatibility with Phoenix master

### DIFF
--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -297,8 +297,8 @@ defmodule Absinthe.Plug.GraphiQL do
   defp find_socket_path(conn, socket) do
     if endpoint = conn.private[:phoenix_endpoint] do
       endpoint.__sockets__
-      |> Enum.find(fn {_, module} ->
-        module == socket
+      |> Enum.find(fn socket_info ->
+        elem(socket_info, 1) == socket
       end)
       |> case do
         {path, _} -> {:ok, path}


### PR DESCRIPTION
On Phoenix master branch `Endpoint.__sockets__` is now returning a 4 elements tuple instead of 2, so I changed the anonymous function the filters it out to work with any size tuple.