### PR TITLE
On errors return 200 so it plays nice with Apollo

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -254,7 +254,7 @@ defmodule Absinthe.Plug do
 
       {:ok, %{errors: _} = result} ->
         conn
-        |> encode(400, result, config)
+        |> encode(200, result, config)
 
       {:ok, result} when is_list(result) ->
         conn

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -148,7 +148,7 @@ defmodule Absinthe.PlugTest do
   test "document with error returns validation errors" do
     opts = Absinthe.Plug.init(schema: TestSchema)
 
-    assert %{status: 400, resp_body: resp_body} = conn(:get, "/", query: @query)
+    assert %{status: 200, resp_body: resp_body} = conn(:get, "/", query: @query)
     |> put_req_header("content-type", "application/x-www-form-urlencoded")
     |> plug_parser
     |> Absinthe.Plug.call(opts)
@@ -165,7 +165,7 @@ defmodule Absinthe.PlugTest do
   test "document with too much complexity returns analysis errors" do
     opts = Absinthe.Plug.init(schema: TestSchema, analyze_complexity: true, max_complexity: 99)
 
-    assert %{status: 400, resp_body: resp_body} = conn(:get, "/", query: @complex_query)
+    assert %{status: 200, resp_body: resp_body} = conn(:get, "/", query: @complex_query)
     |> put_req_header("content-type", "application/x-www-form-urlencoded")
     |> plug_parser
     |> Absinthe.Plug.call(opts)
@@ -296,7 +296,7 @@ defmodule Absinthe.PlugTest do
 
       upload = %Plug.Upload{}
 
-      assert %{status: 400, resp_body: resp_body} = conn(:post, "/", %{"query" => query, "a" => upload})
+      assert %{status: 200, resp_body: resp_body} = conn(:post, "/", %{"query" => query, "a" => upload})
       |> put_req_header("content-type", "multipart/form-data")
       |> call(opts)
 
@@ -309,7 +309,7 @@ defmodule Absinthe.PlugTest do
       {uploadTest(fileA: "a")}
       """
 
-      assert %{status: 400, resp_body: resp_body} = conn(:post, "/", %{"query" => query})
+      assert %{status: 200, resp_body: resp_body} = conn(:post, "/", %{"query" => query})
       |> put_req_header("content-type", "multipart/form-data")
       |> call(opts)
 
@@ -322,7 +322,7 @@ defmodule Absinthe.PlugTest do
 
     query = "{expensive}"
 
-    assert %{status: 400, resp_body: resp_body} = conn(:post, "/", %{"query" => query})
+    assert %{status: 200, resp_body: resp_body} = conn(:post, "/", %{"query" => query})
     |> put_req_header("content-type", "multipart/form-data")
     |> call(opts)
 


### PR DESCRIPTION
This relates to: https://github.com/absinthe-graphql/absinthe/issues/554

In nutshell: Apollo.js assumes that we get 200 OK even on errors. GraphQL specification does not seem to care what status codes are in use (at least I can't find it), so I *think* it might be reasonable to assume it's always 200 OK and errors are handled on the layer of protocol rather than transport (HTTP) unless catastrophic failure happens (500 & friends).

This pull request changes the current behavior of returning 400 in case "errors" are set, to returning 200.