### PR TITLE
WIP: Update to playground 1.6.1

### DIFF
--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -52,7 +52,7 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
       {"files/open-sans-latin-600.woff2", "files/open-sans-latin-600.woff2"},
       {"files/open-sans-latin-700.woff2", "files/open-sans-latin-700.woff2"},
     ]},
-    {"@absinthe/graphql-playground", "1.3.4", [
+    {"@absinthe/graphql-playground", "1.3.5", [
       {"dist/main.js", "playground.js"}
     ]},
     {"@absinthe/socket-graphiql", "0.1.1", [

--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -52,9 +52,8 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
       {"files/open-sans-latin-600.woff2", "files/open-sans-latin-600.woff2"},
       {"files/open-sans-latin-700.woff2", "files/open-sans-latin-700.woff2"},
     ]},
-    {"@absinthe/graphql-playground", "1.2.0", [
-      {"build/static/css/middleware.css", "playground.css"},
-      {"build/static/js/middleware.js", "playground.js"}
+    {"@absinthe/graphql-playground", "1.3.4", [
+      {"dist/main.js", "playground.js"}
     ]},
     {"@absinthe/socket-graphiql", "0.1.1", [
       {"compat/umd/index.js", "socket-graphiql.js"},

--- a/lib/absinthe/plug/graphiql/graphiql_playground.html.eex
+++ b/lib/absinthe/plug/graphiql/graphiql_playground.html.eex
@@ -9,51 +9,15 @@ add "&raw" to the end of the URL within a browser.
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
 
-  <title>GraphiQL Playground</title>
+  <title>GraphQL Playground</title>
 
   <link href="<%= assets["typeface-open-sans/index.css"] %>" rel="stylesheet">
   <link href="<%= assets["typeface-source-code-pro/index.css"] %>" rel="stylesheet">
-  <link rel="stylesheet" media="screen" href="<%= assets["@absinthe/graphql-playground/playground.css"] %>">
 </head>
 <body>
-  <div id="root">
-    <style>
-      body {
-        background-color: #172a3a;
-        font-family: Open Sans, sans-serif;
-        height: 90vh
-      }
-
-      #root {
-        height: 100%;
-        width: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center
-      }
-
-      .loading {
-        font-size: 32px;
-        font-weight: 200;
-        color: rgba(255, 255, 255, .6);
-        margin-left: 20px
-      }
-
-      img {
-        width: 78px;
-        height: 78px
-      }
-
-      .title {
-        font-weight: 400
-      }
-    </style>
-    <div class="loading">Loading
-      <span class="title">GraphQL Playground</span>
-    </div>
-  </div>
+  <div id="app"></div>
   <script>
     var options = {};
     var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
@@ -66,7 +30,7 @@ add "&raw" to the end of the URL within a browser.
       options.subscriptionEndpoint = <%= socket_url %>;
     <% end %>
 
-    window.addEventListener("load", function (n) { GraphQLPlayground.init(document.getElementById("root"), options) })
+    window.addEventListener("load", function (n) { GraphQLPlayground.init(options) });
   </script>
   <script type="text/javascript" src="<%= assets["@absinthe/graphql-playground/playground.js"] %>"></script>
 </body>


### PR DESCRIPTION
Now that Playground with the 1.6.X release is supporting custom apollo link, there is no reason anymore to fork it. Unfortunately, we can't use the html version they are providing as it does not support passing a custom apollo link...

So I created a mini react app that bundles GraphQL Playground with a custom link compatible with Apollo.

Everything should work but I have yet to test subscriptions.