### PR TITLE
pass query-string params to websocket

### DIFF
--- a/lib/absinthe/plug/graphiql/graphiql_workspace.html.eex
+++ b/lib/absinthe/plug/graphiql/graphiql_workspace.html.eex
@@ -25,7 +25,21 @@ add "&raw" to the end of the URL within a browser.
   <script src="<%= assets["@absinthe/socket-graphiql/socket-graphiql.js"] %>"></script>
   <script type="text/javascript">
     function absintheSubscriptionsClientBuilder(url, connectionParams) {
-      return new AbsintheSocketGraphiql.SubscriptionsClient(url, {params: connectionParams});
+
+      const urlObject = new URL(url);
+
+      const urlParams = urlObject.search
+                          .slice(1)
+                          .split('&')
+                          .filter(s => s !== '')
+                          .map(p => p.split('='))
+                          .reduce((obj, [key, value]) => {
+                            obj[key] = value;
+                            return obj;
+                          }, {});
+
+      return new AbsintheSocketGraphiql.SubscriptionsClient(`${urlObject.origin}${urlObject.pathname}`,
+                                                            {params: Object.assign(urlParams, connectionParams)});
     }
 
     var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";


### PR DESCRIPTION
Before:
![screen shot 2018-07-11 at 16 45 38](https://user-images.githubusercontent.com/33688567/42575762-e11c111c-8529-11e8-93ba-f804b17e0490.png)
Produced error
```
'ws://127.0.0.1:4000/graphql/backoffice/chat?s=1&sf=chat/websocket&vsn=2.0.0' failed: Error during WebSocket handshake: Unexpected response code: 404
```
Because URL was passed to phoenix.js as it was, resulted URL was incorrect (problem with `/websocket` concat)

This PR resolve this issue and query string is passed as `params` option field