### PR TITLE
Reject non-batch JSON payloads

### DIFF
--- a/lib/absinthe/plug/request.ex
+++ b/lib/absinthe/plug/request.ex
@@ -45,7 +45,7 @@ defmodule Absinthe.Plug.Request do
       # Phoenix puts parsed params under the "_json" key when the
       # structure is an array; otherwise it's just the keys themselves,
       # and they may sit in the body or in the params
-      batch? = Map.has_key?(params, "_json") && is_list(params["_json"])
+      batch? = Map.has_key?(params, "_json")
       {:ok, conn, build_request(body, params, config, batch?: batch?)}
     end
   end
@@ -65,7 +65,6 @@ defmodule Absinthe.Plug.Request do
       extra_keys: extra_keys,
     }
   end
-
   defp build_request(body, params, config, batch?: false) do
     queries =
       body

--- a/lib/absinthe/plug/request.ex
+++ b/lib/absinthe/plug/request.ex
@@ -45,7 +45,7 @@ defmodule Absinthe.Plug.Request do
       # Phoenix puts parsed params under the "_json" key when the
       # structure is an array; otherwise it's just the keys themselves,
       # and they may sit in the body or in the params
-      batch? = Map.has_key?(params, "_json")
+      batch? = Map.has_key?(params, "_json") && is_list(params["_json"])
       {:ok, conn, build_request(body, params, config, batch?: batch?)}
     end
   end
@@ -65,6 +65,19 @@ defmodule Absinthe.Plug.Request do
       extra_keys: extra_keys,
     }
   end
+
+  defp build_request(body, %{"_json" => query}, config, batch?: false) do
+    queries =
+      body
+      |> Query.parse(query, config)
+      |> List.wrap
+
+    %__MODULE__{
+      queries: queries,
+      batch: false,
+    }
+  end
+
   defp build_request(body, params, config, batch?: false) do
     queries =
       body

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -107,19 +107,17 @@ defmodule Absinthe.PlugTest do
     assert resp_body == @foo_result
   end
 
-
-  test "content-type application/json works with error" do
+  test "content-type application/json _json query works" do
     opts = Absinthe.Plug.init(schema: TestSchema)
-    bad_query = Poison.encode!(%{"_json" => "{\"query\": \"\"}"})
+    json_query = Poison.encode!(%{"_json" => %{"query" => @query}})
 
-    assert %{status: 200, resp_body: resp_body} = conn(:post, "/", bad_query)
+    assert %{status: 200, resp_body: resp_body} = conn(:post, "/", json_query)
     |> put_req_header("content-type", "application/json")
     |> plug_parser
     |> Absinthe.Plug.call(opts)
 
-    # raises a BadMapError
+    assert resp_body == @foo_result
   end
-
 
   @mutation """
   mutation AddItem {

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -109,9 +109,11 @@ defmodule Absinthe.PlugTest do
 
   test "content-type application/json _json query works" do
     opts = Absinthe.Plug.init(schema: TestSchema)
-    json_query = Poison.encode!(%{"_json" => %{"query" => @query}})
+    query = """
+    { "query": "{ item(id: \\"foo\\") { name } }" }
+    """
 
-    assert %{status: 200, resp_body: resp_body} = conn(:post, "/", json_query)
+    assert %{status: 200, resp_body: resp_body} = conn(:post, "/", Poison.encode!(query))
     |> put_req_header("content-type", "application/json")
     |> plug_parser
     |> Absinthe.Plug.call(opts)

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -107,6 +107,20 @@ defmodule Absinthe.PlugTest do
     assert resp_body == @foo_result
   end
 
+
+  test "content-type application/json works with error" do
+    opts = Absinthe.Plug.init(schema: TestSchema)
+    bad_query = Poison.encode!(%{"_json" => "{\"query\": \"\"}"})
+
+    assert %{status: 200, resp_body: resp_body} = conn(:post, "/", bad_query)
+    |> put_req_header("content-type", "application/json")
+    |> plug_parser
+    |> Absinthe.Plug.call(opts)
+
+    # raises a BadMapError
+  end
+
+
   @mutation """
   mutation AddItem {
     addItem(name: "Baz") {

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -107,18 +107,18 @@ defmodule Absinthe.PlugTest do
     assert resp_body == @foo_result
   end
 
-  test "content-type application/json _json query works" do
+  test "content-type application/json fails with JSON encoded query strings" do
     opts = Absinthe.Plug.init(schema: TestSchema)
     query = """
     { "query": "{ item(id: \\"foo\\") { name } }" }
     """
 
-    assert %{status: 200, resp_body: resp_body} = conn(:post, "/", Poison.encode!(query))
+    assert %{status: 400, resp_body: resp_body} = conn(:post, "/", Poison.encode!(query))
     |> put_req_header("content-type", "application/json")
     |> plug_parser
     |> Absinthe.Plug.call(opts)
 
-    assert resp_body == @foo_result
+    assert resp_body ==  "Could not parse JSON."
   end
 
   @mutation """

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -107,7 +107,7 @@ defmodule Absinthe.PlugTest do
     assert resp_body == @foo_result
   end
 
-  test "content-type application/json fails with JSON encoded query strings" do
+  test "content-type application/json fails with improperly encoded query strings" do
     opts = Absinthe.Plug.init(schema: TestSchema)
     query = """
     { "query": "{ item(id: \\"foo\\") { name } }" }


### PR DESCRIPTION
It is possible to send a non-batch query as a json string. For example:
```
"{
    \"query\": \"{ query }\"
}"
```
This causes a BadMapError to fire at https://github.com/absinthe-graphql/absinthe_plug/blob/master/lib/absinthe/plug/request/query.ex#L132 because it is getting a tuple from the `Enum.map` here: https://github.com/absinthe-graphql/absinthe_plug/blob/master/lib/absinthe/plug/request.ex#L55

The solution is to treat a non-batch json payload as a regular query once it is properly extracted.