### PR TITLE
Change response shape to work together with apollo-link-batch-http

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -404,9 +404,7 @@ defmodule Absinthe.Plug do
       results
       |> Enum.zip(request.extra_keys)
       |> Enum.map(fn {result, extra_keys} ->
-        Map.merge(extra_keys, %{
-          payload: result
-        })
+        Map.merge(extra_keys, result)
       end)
 
     {conn, {:ok, results}}

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -161,7 +161,7 @@ defmodule Absinthe.Plug do
           content_type: String.t(),
           before_send: {module, atom},
           log_level: Logger.level(),
-          use_batch_http_link_format: Boolean.t(),
+          use_batch_http_link_format: Boolean.t()
         ]
 
   @doc """
@@ -429,9 +429,15 @@ defmodule Absinthe.Plug do
       results
       |> Enum.zip(request.extra_keys)
       |> Enum.map(fn {result, extra_keys} ->
-          Map.merge(extra_keys, (if config.use_batch_http_link_format, do: result, else: %{
-            payload: result	
-          }))
+        Map.merge(
+          extra_keys,
+          if(config.use_batch_http_link_format,
+            do: result,
+            else: %{
+              payload: result
+            }
+          )
+        )
       end)
 
     {conn, {:ok, results}}

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -160,7 +160,8 @@ defmodule Absinthe.Plug do
           serializer: module | {module, Keyword.t()},
           content_type: String.t(),
           before_send: {module, atom},
-          log_level: Logger.level()
+          log_level: Logger.level(),
+          use_batch_http_link_format: Boolean.t(),
         ]
 
   @doc """
@@ -206,6 +207,8 @@ defmodule Absinthe.Plug do
 
     before_send = Keyword.get(opts, :before_send)
 
+    use_batch_http_link_format = Keyword.get(opts, :use_batch_http_link_format, false)
+
     %{
       adapter: adapter,
       context: context,
@@ -219,7 +222,8 @@ defmodule Absinthe.Plug do
       content_type: content_type,
       log_level: log_level,
       pubsub: pubsub,
-      before_send: before_send
+      before_send: before_send,
+      use_batch_http_link_format: use_batch_http_link_format
     }
   end
 
@@ -425,7 +429,9 @@ defmodule Absinthe.Plug do
       results
       |> Enum.zip(request.extra_keys)
       |> Enum.map(fn {result, extra_keys} ->
-        Map.merge(extra_keys, result)
+          Map.merge(extra_keys, (if config.use_batch_http_link_format, do: result, else: %{
+            payload: result	
+          }))
       end)
 
     {conn, {:ok, results}}

--- a/test/lib/absinthe/plug/transport_batching_test.exs
+++ b/test/lib/absinthe/plug/transport_batching_test.exs
@@ -37,6 +37,11 @@ defmodule Absinthe.Plug.TransportBatchingTest do
     %{"payload" => %{"data" => %{"item" => %{"name" => "Bar"}}}}
   ]
 
+  @apollo_batch_link_foo_result [
+    %{"data" => %{"item" => %{"name" => "Foo"}}},
+    %{"data" => %{"item" => %{"name" => "Bar"}}}
+  ]
+
   @apollo_variable_query """
   [{
     "query": "query FooQuery($id: ID!){ item(id: $id) { name } }",
@@ -92,6 +97,18 @@ defmodule Absinthe.Plug.TransportBatchingTest do
              |> absinthe_plug(opts)
 
     assert @apollo_foo_result == resp_body
+  end
+
+  test "single batched query in apollo-link-batch-http format works" do
+    opts = Absinthe.Plug.init(schema: TestSchema, use_batch_http_link_format: true)
+
+    assert %{status: 200, resp_body: resp_body} =
+             conn(:post, "/", @apollo_query)
+             |> put_req_header("content-type", "application/json")
+             |> plug_parser
+             |> absinthe_plug(opts)
+
+    assert @apollo_batch_link_foo_result == resp_body
   end
 
   test "single batched query in apollo format works with variables" do


### PR DESCRIPTION
It seems that the new version of apollo client expects the data to not be wrapped in ```payload```, and current format causes errors with writing to cache. 