### PR TITLE
Revert "Point to the correct json config option"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Basic Usage:
 plug Plug.Parsers,
   parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
   pass: ["*/*"],
-  json_codec: Poison
+  json_decoder: Poison
 
 plug Absinthe.Plug,
   schema: MyAppWeb.Schema
@@ -60,7 +60,7 @@ router like:
 plug Plug.Parsers,
   parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
   pass: ["*/*"],
-  json_codec: Poison
+  json_decoder: Poison
 
 forward "/api",
   to: Absinthe.Plug,

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -9,7 +9,7 @@ defmodule Absinthe.Plug do
       plug Plug.Parsers,
         parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
         pass: ["*/*"],
-        json_codec: Poison
+        json_decoder: Poison
 
       plug Absinthe.Plug,
         schema: MyAppWeb.Schema
@@ -20,7 +20,7 @@ defmodule Absinthe.Plug do
       plug Plug.Parsers,
         parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
         pass: ["*/*"],
-        json_codec: Poison
+        json_decoder: Poison
 
       forward "/api",
         to: Absinthe.Plug,

--- a/lib/absinthe/plug/parser.ex
+++ b/lib/absinthe/plug/parser.ex
@@ -11,7 +11,7 @@ defmodule Absinthe.Plug.Parser do
       plug Plug.Parsers,
         parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
         pass: ["*/*"],
-        json_codec: Poison
+        json_decoder: Poison
 
       plug Absinthe.Plug,
         schema: MyAppWeb.Schema

--- a/test/lib/absinthe/graphiql_test.exs
+++ b/test/lib/absinthe/graphiql_test.exs
@@ -167,13 +167,11 @@ defmodule Absinthe.Plug.GraphiQLTest do
   end
 
   defp plug_parser(conn) do
-    opts =
-      Plug.Parsers.init(
-        parsers: [:urlencoded, :multipart, :json],
-        pass: ["*/*"],
-        json_codec: Poison
-      )
-
+    opts = Plug.Parsers.init(
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      json_decoder: Poison
+    )
     Plug.Parsers.call(conn, opts)
   end
 

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -17,12 +17,10 @@ defmodule Absinthe.Plug.TestCase do
   end
 
   def plug_parser(conn) do
-    opts =
-      Plug.Parsers.init(
-        parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
-        json_codec: Poison
-      )
-
+    opts = Plug.Parsers.init(
+      parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
+      json_decoder: Poison
+    )
     Plug.Parsers.call(conn, opts)
   end
 


### PR DESCRIPTION
I think this PR was wrong, it confused the `plug` config option with `the `absinthe_plug` config option. Sorry about that!!

Reverts absinthe-graphql/absinthe_plug#180