### PR TITLE
Properly detect batch requests

### DIFF
--- a/lib/absinthe/plug/request.ex
+++ b/lib/absinthe/plug/request.ex
@@ -43,7 +43,7 @@ defmodule Absinthe.Plug.Request do
 
     with {:ok, conn, body, params} <- extract_body_and_params(conn, config) do
       # Plug puts parsed params under the "_json" key when the
-      # structure is an array; otherwise it's just the keys themselves,
+      # structure is not a map; otherwise it's just the keys themselves,
       # and they may sit in the body or in the params
       batch? = Map.has_key?(params, "_json") && is_list(params["_json"])
       {:ok, conn, build_request(body, params, config, batch?: batch?)}

--- a/lib/absinthe/plug/request.ex
+++ b/lib/absinthe/plug/request.ex
@@ -42,10 +42,10 @@ defmodule Absinthe.Plug.Request do
     })
 
     with {:ok, conn, body, params} <- extract_body_and_params(conn, config) do
-      # Phoenix puts parsed params under the "_json" key when the
+      # Plug puts parsed params under the "_json" key when the
       # structure is an array; otherwise it's just the keys themselves,
       # and they may sit in the body or in the params
-      batch? = Map.has_key?(params, "_json")
+      batch? = Map.has_key?(params, "_json") && is_list(params["_json"])
       {:ok, conn, build_request(body, params, config, batch?: batch?)}
     end
   end


### PR DESCRIPTION
This PR fixes a bug that arises based on an assumption that anything inside the `params["_json"]` value will be an array. It is actually the case that it is simply a non-map value.

We encountered this because we received a request which was double-encoded, and thus a simple JSON string. That should return a 400, not blow up with a 500.

I submitted a PR to `plug` to properly document it's actual behavior: https://github.com/elixir-plug/plug/pull/786

Following up on https://github.com/absinthe-graphql/absinthe_plug/pull/178 for @emeryotopalik

@benwilson512 