### PR TITLE
Always return a JSON body

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -249,7 +249,7 @@ defmodule Absinthe.Plug do
     case result do
       {:input_error, msg} ->
         conn
-        |> send_resp(400, msg)
+        |> encode(400, error_result(msg), config)
 
       {:ok, %{"subscribed" => topic}} ->
         conn
@@ -269,11 +269,11 @@ defmodule Absinthe.Plug do
 
       {:error, {:http_method, text}, _} ->
         conn
-        |> send_resp(405, text)
+        |> encode(405, error_result(text), config)
 
       {:error, error, _} when is_binary(error) ->
         conn
-        |> send_resp(500, error)
+        |> encode(500, error_result(error), config)
 
     end
   end
@@ -484,4 +484,6 @@ defmodule Absinthe.Plug do
     json_codec.module.encode!(value, json_codec.opts)
   end
 
+  @doc false
+  def error_result(message), do: %{"errors" => [%{"message" => message}]}
 end

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -123,7 +123,8 @@ defmodule Absinthe.PlugTest do
     |> plug_parser
     |> Absinthe.Plug.call(opts)
 
-    assert resp_body == "Can only perform a mutation from a POST request"
+    message = "Can only perform a mutation from a POST request"
+    assert %{"errors" => [%{"message" => ^message}]} = resp_body |> Poison.decode!
   end
 
   @query """
@@ -142,7 +143,8 @@ defmodule Absinthe.PlugTest do
     |> plug_parser
     |> Absinthe.Plug.call(opts)
 
-    assert resp_body == opts[:no_query_message]
+    message = opts[:no_query_message]
+    assert %{"errors" => [%{"message" => ^message}]} = resp_body |> Poison.decode!
   end
 
   test "document with error returns validation errors" do


### PR DESCRIPTION
This PR ensures that we always return a JSON response for any request. 

The GraphQL spec states that the response should always be a map: https://facebook.github.io/graphql/June2018/#sec-Response-Format

Also, clients will often try to decode the response body as JSON and when it's raw text that will fail.

This would technically change existing behavior, so I'm open to feedback...

@benwilson512 
Fixes #176