### PR TITLE
Make poison dependency optional

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Absinthe.Plug.Mixfile do
     [
       {:plug, "~> 1.3.2 or ~> 1.4"},
       {:absinthe, "~> 1.4.11"},
-      {:poison, ">= 0.0.0", only: [:dev, :test]},
+      {:poison, ">= 0.0.0", only: [:dev, :test], optional: true},
       {:ex_doc, "~> 0.18.0", only: :dev}
     ]
   end


### PR DESCRIPTION
There's no point to require it on the clients since it's configurable.