### PR TITLE
Support Jason decode error structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ def application do
 end
 ```
 
-`Absinthe.Plug` also requires a JSON codec. Poison works out of the box.
+`Absinthe.Plug` also requires a JSON codec. `Jason` and `Poison` work out of the box.
 
 ```elixir
 def deps do

--- a/lib/absinthe/plug/request.ex
+++ b/lib/absinthe/plug/request.ex
@@ -114,8 +114,8 @@ defmodule Absinthe.Plug.Request do
     else
       {:error, {:invalid, token, pos}} ->
         {:input_error, "Could not parse JSON. Invalid token `#{token}` at position #{pos}"}
-      {:error, %{position: pos, token: token}} ->
-        {:input_error, "Could not parse JSON. Invalid token `#{token}` at position #{pos}"}
+      {:error, %{__exception__: true} = exception} ->
+        {:input_error, "Could not parse JSON. #{Exception.message(exception)}"}
       %{} ->
         {:ok, conn, body, conn.params}
     end

--- a/lib/absinthe/plug/request.ex
+++ b/lib/absinthe/plug/request.ex
@@ -114,6 +114,8 @@ defmodule Absinthe.Plug.Request do
     else
       {:error, {:invalid, token, pos}} ->
         {:input_error, "Could not parse JSON. Invalid token `#{token}` at position #{pos}"}
+      {:error, %{position: pos, token: token}} ->
+        {:input_error, "Could not parse JSON. Invalid token `#{token}` at position #{pos}"}
       %{} ->
         {:ok, conn, body, conn.params}
     end


### PR DESCRIPTION
The only hitch we saw when adopting the `Jason` library is that this bit is hard-coded to the error response structure of `Poison`. (side note I'm pretty sure this structure changes in Poison 4)

This PR simply adds a clause that will match the `Jason` exception struct w/o actually referencing it by name..

* https://github.com/michalmuskala/jason/blob/master/lib/decoder.ex#L4

@benwilson512 