### PR TITLE
Ensure `ssl` application is started when downloading assets

### DIFF
--- a/lib/mix/tasks/absinthe.plug.graphiql.assets.download.ex
+++ b/lib/mix/tasks/absinthe.plug.graphiql.assets.download.ex
@@ -6,7 +6,8 @@ defmodule Mix.Tasks.Absinthe.Plug.Graphiql.Assets.Download do
   def run(args) do
     Mix.Absinthe.Plug.GraphiQL.AssetsTask.run(args)
 
-    Application.ensure_all_started(:inets)
+    {:ok, _} = Application.ensure_all_started(:inets)
+    {:ok, _} = Application.ensure_all_started(:ssl)
 
     Absinthe.Plug.GraphiQL.Assets.get_remote_asset_mappings()
     |> Enum.map(&download_file/1)


### PR DESCRIPTION
Fix `ssl_not_started` error when downloading assets

Without ensuring `ssl` application is started, depending on project, you might end up with this:

```
$ mix absinthe.plug.graphiql.assets.download

    ** (MatchError) no match of right hand side value: {:error, {:failed_connect, [{:to_address, {'cdn.jsdelivr.net', 443}}, {:inet, [:inet], :ssl_not_started}]}}
        lib/mix/tasks/absinthe.plug.graphiql.assets.download.ex:17: Mix.Tasks.Absinthe.Plug.Graphiql.Assets.Download.download_file/1
        (elixir) lib/enum.ex:1327: Enum.-map/2-lists^map/1-0-/2
        (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
        (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```