### PR TITLE
allow to set default query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v1.5.0
 
 - Basically no changes in Absinthe.Plug, but required for Absinthe 1.5 pre-release support
 - Chore: Update Plug. Get rid of plug compilation warnings
+- Feature: allow to pass a default query to GraphiQL interface
 
 v1.4.6
 

--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -181,6 +181,7 @@ defmodule Absinthe.Plug.GraphiQL do
     |> Map.put(:assets, assets)
     |> Map.put(:socket, Keyword.get(opts, :socket))
     |> Map.put(:socket_url, Keyword.get(opts, :socket_url))
+    |> Map.put(:default_query, Keyword.get(opts, :default_query, ""))
     |> set_pipeline
   end
 
@@ -332,14 +333,14 @@ defmodule Absinthe.Plug.GraphiQL do
     end
   end
 
-  @render_defaults %{query: "", var_string: "", results: ""}
+  @render_defaults %{var_string: "", results: ""}
 
   @spec render_interface(Plug.Conn.t(), :advanced | :simple | :playground, map()) ::
           Plug.Conn.t()
   defp render_interface(conn, interface, opts)
 
   defp render_interface(conn, :simple, opts) do
-    opts = Map.merge(@render_defaults, opts)
+    opts = opts_with_default(opts)
 
     graphiql_html(
       opts[:query],
@@ -352,7 +353,7 @@ defmodule Absinthe.Plug.GraphiQL do
   end
 
   defp render_interface(conn, :advanced, opts) do
-    opts = Map.merge(@render_defaults, opts)
+    opts = opts_with_default(opts)
 
     graphiql_workspace_html(
       opts[:query],
@@ -366,7 +367,7 @@ defmodule Absinthe.Plug.GraphiQL do
   end
 
   defp render_interface(conn, :playground, opts) do
-    opts = Map.merge(@render_defaults, opts)
+    opts = opts_with_default(opts)
 
     graphiql_playground_html(
       default_url(opts[:default_url]),
@@ -374,6 +375,12 @@ defmodule Absinthe.Plug.GraphiQL do
       opts[:assets]
     )
     |> rendered(conn)
+  end
+
+  defp opts_with_default(opts) do
+    defaults = Map.put(@render_defaults, :query, opts[:default_query])
+
+    Map.merge(defaults, opts)
   end
 
   defp default_url(nil), do: "window.location.origin + window.location.pathname"

--- a/test/lib/absinthe/graphiql_test.exs
+++ b/test/lib/absinthe/graphiql_test.exs
@@ -77,17 +77,21 @@ defmodule Absinthe.Plug.GraphiQLTest do
 
   test "default_query option is rendered" do
     default_query = "default_query"
-    opts = Absinthe.Plug.GraphiQL.init(schema: TestSchema,
-      default_query: default_query)
 
-    assert %{status: status, resp_body: body} = conn(:get, "/")
-    |> plug_parser
-    |> put_req_header("accept", "text/html")
-    |> Absinthe.Plug.GraphiQL.call(opts)
+    opts =
+      Absinthe.Plug.GraphiQL.init(
+        schema: TestSchema,
+        default_query: default_query
+      )
+
+    assert %{status: status, resp_body: body} =
+             conn(:get, "/")
+             |> plug_parser
+             |> put_req_header("accept", "text/html")
+             |> Absinthe.Plug.GraphiQL.call(opts)
 
     assert 200 == status
     assert String.contains?(body, "defaultQuery: '#{default_query}'")
-
   end
 
   test "default_url option works a function of arity 0" do

--- a/test/lib/absinthe/graphiql_test.exs
+++ b/test/lib/absinthe/graphiql_test.exs
@@ -75,6 +75,21 @@ defmodule Absinthe.Plug.GraphiQLTest do
     assert body |> String.contains?("defaultHeaders: " <> header_json)
   end
 
+  test "default_query option is rendered" do
+    default_query = "default_query"
+    opts = Absinthe.Plug.GraphiQL.init(schema: TestSchema,
+      default_query: default_query)
+
+    assert %{status: status, resp_body: body} = conn(:get, "/")
+    |> plug_parser
+    |> put_req_header("accept", "text/html")
+    |> Absinthe.Plug.GraphiQL.call(opts)
+
+    assert 200 == status
+    assert String.contains?(body, "defaultQuery: '#{default_query}'")
+
+  end
+
   test "default_url option works a function of arity 0" do
     opts =
       Absinthe.Plug.GraphiQL.init(


### PR DESCRIPTION
Changelog:
- allow passing `default_query` parameter to `advanced` GraphiQL interface