### PR TITLE
[WIP] Enable to upload multiple files as list_of field

### DIFF
--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -298,6 +298,25 @@ defmodule Absinthe.PlugTest do
       assert resp_body == %{"data" => %{"uploadTest" => "file_a, file_b"}}
     end
 
+    test "work with list_of multiple uploads", %{opts: opts} do
+      query = """
+      {listOfUploadTest(files: "[]files")}
+      """
+
+      upload1 = %Plug.Upload{
+        filename: "file1.ex",
+      }
+      upload2 = %Plug.Upload{
+        filename: "file2.ex",
+      }
+
+      assert %{status: 200, resp_body: resp_body} = conn(:post, "/", %{"query" => query, "files[0]" => upload1, "files[1]" => upload2})
+      |> put_req_header("content-type", "multipart/form-data")
+      |> call(opts)
+
+      assert resp_body == %{"data" => %{"listOfUploadTest" => "file1.ex, file2.ex"}}
+    end
+
     test "work with variables", %{opts: opts} do
       query = """
       query ($auth: String){uploadTest(fileA: "a", fileB: "b", auth: $auth)}

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -38,6 +38,20 @@ defmodule Absinthe.Plug.TestSchema do
       end
     end
 
+    field :list_of_upload_test, :string do
+      arg :files, non_null(list_of(non_null(:upload)))
+
+      resolve fn args, _ ->
+        file_names =
+          args
+          |> Map.get(:files, [])
+          |> List.first
+          |> Enum.map(fn %{filename: filename} -> filename end)
+
+        {:ok, file_names |> Enum.join(", ")}
+      end
+    end
+
     field :user, :string do
       resolve fn _, %{
         context: %{


### PR DESCRIPTION
### Background:
When application allows to upload big amount of files, there is few options how this could be implemented: 
* option1:  define mutation with multiple upload arguments (the number of arguments could be 10+)
* option2: schedule an upload queue on a client and execute upload mutation for each file separately
* option3: use batching and run multiple upload mutations 

In my opinion all 3 options are not comfortable to develop and support.

Alternative solution could be next mutation: 
```
  object :file_mutations do
    field :upload_files, list_of(:file) do
      arg :files, non_null(list_of(non_null(:upload)))

      resolve(&Resolvers.File.handle_files_upload/2)
    end
  end
```


### Problem:
Such alternative approach currently is not supported by absinthe.

### Suggested in this PR solution
Imagine a new convention: when list_of uploads is used for `:files` argument, then client should prefix an argument value with `[]` (prefix is chosen in order to pattern match string) and name each file in form data with `[n]` suffix (where n is a file index in list).
```
$ curl -X POST \\
-F query="{mutation uploadFile(users: \"[]files\", metadata: \"metadata_json\")" \\
-F files[0]=@users.csv \\
-D files[1]=@currencies.csv \\
-F metadata_json=@metadata.json \\
localhost:4000/graphql
```

Closes #139 .

### WIP 
My current solution has a problem: since `:upload type` return a list and argument `:files` is a list_of, resolver receives list of `Plug.Upload` wrapped into one more list. See test.
```
%{
  files: [
    [
      %Plug.Upload{
        content_type: "application/octet-stream",
        filename: "users.csv",
        path: "/tmp/random_name.csv"
      },
      %Plug.Upload{
        content_type: "application/octet-stream",
        filename: "currencies.csv",
        path: "/tmp/random_name.csv"
      }
    ]
  ]
}
```
I have only one suggestion how this could be solved - is to implement middleware (as part of absinthe library), which will unwrap list (`List.flatten`). Or we could introduce new `:upload_list` type, which will handle this task properly.

I will appreciate any feedback and help to properly finish this PR. Of course when solution will be good enough I will update documentation.  