### PR TITLE
Fix DocumentProvider.pipeline/1 typespec

### DIFF
--- a/lib/absinthe/plug/document_provider.ex
+++ b/lib/absinthe/plug/document_provider.ex
@@ -50,7 +50,7 @@ defmodule Absinthe.Plug.DocumentProvider do
   Given a request, determine what part of its configured pipeline
   should be applied during execution.
   """
-  @callback pipeline(Absinthe.Plug.Request.t) :: Absinthe.Pipeline.t
+  @callback pipeline(Absinthe.Plug.Request.Query.t) :: Absinthe.Pipeline.t
 
   @doc """
   Given a request, attempt to process it with this document provider.
@@ -78,7 +78,7 @@ defmodule Absinthe.Plug.DocumentProvider do
   end
 
   @doc false
-  @spec pipeline(Absinthe.Plug.Request.t) :: Absinthe.Pipeline.t
+  @spec pipeline(Absinthe.Plug.Request.Query.t) :: Absinthe.Pipeline.t
   # Determine the remaining pipeline for request, based on the associated
   # document provider.
   def pipeline(%{document_provider: {mod, _}} = request) do

--- a/lib/absinthe/plug/document_provider/default.ex
+++ b/lib/absinthe/plug/document_provider/default.ex
@@ -31,7 +31,7 @@ defmodule Absinthe.Plug.DocumentProvider.Default do
   @behaviour Absinthe.Plug.DocumentProvider
 
   @doc false
-  @spec pipeline(Absinthe.Plug.Request.t) :: Absinthe.Pipeline.t
+  @spec pipeline(Absinthe.Plug.Request.Query.t) :: Absinthe.Pipeline.t
   def pipeline(%{pipeline: as_configured}), do: as_configured
 
   @doc false

--- a/test/lib/absinthe/plug/document_provider_test.exs
+++ b/test/lib/absinthe/plug/document_provider_test.exs
@@ -14,7 +14,7 @@ defmodule Absinthe.Plug.DocumentProviderTest do
     @behaviour Absinthe.Plug.DocumentProvider
 
     @doc false
-    @spec pipeline(Absinthe.Plug.Request.t) :: Absinthe.Pipeline.t
+    @spec pipeline(Absinthe.Plug.Request.Query.t) :: Absinthe.Pipeline.t
     def pipeline(%{pipeline: as_configured}), do: as_configured
 
     @doc false


### PR DESCRIPTION
Hi! Just a small typo fix 😄 

The typespec for the `DocumentProvider.pipeline/1` callback is not the right one. The function does not receive a `%Absinthe.Plug.Request{}` struct — it receives a `%Absinthe.Plug.Request.Query{}` struct.

Thank you!