### PR TITLE
Fix compiled documents telemetry integration

### DIFF
--- a/lib/absinthe/plug/document_provider/compiled.ex
+++ b/lib/absinthe/plug/document_provider/compiled.ex
@@ -63,6 +63,7 @@ defmodule Absinthe.Plug.DocumentProvider.Compiled do
       # Can be overridden in the document provider module
       @compilation_pipeline Absinthe.Pipeline.for_document(nil, jump_phases: false)
                             |> Absinthe.Pipeline.before(Absinthe.Phase.Document.Variables)
+                            |> Absinthe.Pipeline.without(Absinthe.Phase.Telemetry)
 
       import unquote(__MODULE__), only: [provide: 2, provide: 1]
 

--- a/lib/absinthe/plug/document_provider/compiled.ex
+++ b/lib/absinthe/plug/document_provider/compiled.ex
@@ -94,8 +94,12 @@ defmodule Absinthe.Plug.DocumentProvider.Compiled do
       phase is not a subset of the full pipeline.
       """
       def pipeline(%{pipeline: as_configured}) do
+        remaining_pipeline_marker = __absinthe_plug_doc__(:remaining_pipeline)
+        telemetry_phase = {Absinthe.Phase.Telemetry, [:execute, :operation, :start]}
+
         as_configured
-        |> Absinthe.Pipeline.from(__absinthe_plug_doc__(:remaining_pipeline))
+        |> Absinthe.Pipeline.from(remaining_pipeline_marker)
+        |> Absinthe.Pipeline.insert_before(remaining_pipeline_marker, telemetry_phase)
       end
 
       defoverridable pipeline: 1

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Absinthe.Plug.Mixfile do
   defp deps do
     [
       {:plug, "~> 1.3.2 or ~> 1.4"},
-      {:absinthe, "~> 1.5.0-alpha.0"},
+      {:absinthe, git: "https://github.com/absinthe-graphql/absinthe.git", branch: "master"},
       {:jason, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.20.2", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Absinthe.Plug.Mixfile do
   defp deps do
     [
       {:plug, "~> 1.3.2 or ~> 1.4"},
-      {:absinthe, git: "https://github.com/absinthe-graphql/absinthe.git", branch: "master"},
+      {:absinthe, "~> 1.5.0-beta.0"},
       {:jason, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.20.2", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -3,9 +3,10 @@
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.5.6", "da47b331b1fe0a5f0380cc3a6967200eac5e1daaa9c6bff4b0310b3fcc12b98f", [:mix], [{:nimble_parsec, "~> 0.4.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "absinthe": {:git, "https://github.com/absinthe-graphql/absinthe.git", "b6598b579fc340b0c353814e959906c8f5ea226b", [branch: "master"]},
+  "absinthe": {:hex, :absinthe, "1.5.0-beta.0", "6d45898ffa75f3f7bc341ce46571e7ec2892cb98852595cdcb2c66073894bd8a", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}, {:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "absinthe": {:hex, :absinthe, "1.5.0-alpha.4", "fa6dbd492db949a1193c57ddf9f382c55247082774b2b7ddd1bb44c4472e1a6b", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}, {:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "absinthe": {:git, "https://github.com/absinthe-graphql/absinthe.git", "b6598b579fc340b0c353814e959906c8f5ea226b", [branch: "master"]},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},

--- a/test/lib/absinthe/plug/document_provider/compiled_test.exs
+++ b/test/lib/absinthe/plug/document_provider/compiled_test.exs
@@ -3,24 +3,6 @@ defmodule Absinthe.Plug.DocumentProvider.CompiledTest do
   alias Absinthe.Plug.TestSchema
   alias Absinthe.Plug.DocumentProvider.Compiled
 
-  defmodule LiteralDocuments do
-    use Absinthe.Plug.DocumentProvider.Compiled
-
-    provide("1", """
-    query FooQuery($id: ID!) {
-      item(id: $id) {
-        name
-      }
-    }
-    """)
-
-    provide("2", """
-    query GetUser {
-      user
-    }
-    """)
-  end
-
   defmodule ExtractedDocuments do
     use Absinthe.Plug.DocumentProvider.Compiled
 
@@ -44,7 +26,10 @@ defmodule Absinthe.Plug.DocumentProvider.CompiledTest do
 
   test "works using documents provided as literals" do
     opts =
-      Absinthe.Plug.init(schema: TestSchema, document_providers: [__MODULE__.LiteralDocuments])
+      Absinthe.Plug.init(
+        schema: TestSchema,
+        document_providers: [Absinthe.Plug.TestLiteralDocuments]
+      )
 
     assert %{status: 200, resp_body: resp_body} =
              conn(:post, "/", %{"id" => "1", "variables" => %{"id" => "foo"}})
@@ -76,7 +61,10 @@ defmodule Absinthe.Plug.DocumentProvider.CompiledTest do
 
   test "context passed correctly to resolvers with documents provided as literals" do
     opts =
-      Absinthe.Plug.init(schema: TestSchema, document_providers: [__MODULE__.LiteralDocuments])
+      Absinthe.Plug.init(
+        schema: TestSchema,
+        document_providers: [Absinthe.Plug.TestLiteralDocuments]
+      )
 
     assert %{status: 200, resp_body: resp_body} =
              conn(:post, "/", %{"id" => "2"})
@@ -102,11 +90,13 @@ defmodule Absinthe.Plug.DocumentProvider.CompiledTest do
   end
 
   test ".get compiled" do
-    assert %Absinthe.Blueprint{} = Compiled.get(LiteralDocuments, "1")
-    assert %Absinthe.Blueprint{} = Compiled.get(LiteralDocuments, "1", :compiled)
+    assert %Absinthe.Blueprint{} = Compiled.get(Absinthe.Plug.TestLiteralDocuments, "1")
+
+    assert %Absinthe.Blueprint{} =
+             Compiled.get(Absinthe.Plug.TestLiteralDocuments, "1", :compiled)
   end
 
   test ".get source" do
-    assert @query == Compiled.get(LiteralDocuments, "1", :source)
+    assert @query == Compiled.get(Absinthe.Plug.TestLiteralDocuments, "1", :source)
   end
 end

--- a/test/support/test_literal_documents.ex
+++ b/test/support/test_literal_documents.ex
@@ -1,0 +1,17 @@
+defmodule Absinthe.Plug.TestLiteralDocuments do
+  use Absinthe.Plug.DocumentProvider.Compiled
+
+  provide("1", """
+  query FooQuery($id: ID!) {
+    item(id: $id) {
+      name
+    }
+  }
+  """)
+
+  provide("2", """
+  query GetUser {
+    user
+  }
+  """)
+end


### PR DESCRIPTION
This PR makes sure that compiled documents play nicely with `telemetry` integration and ensures they execute instrumentation events like standard documents.

Fix provided by @maartenvanvliet 

Fixes https://github.com/absinthe-graphql/absinthe/issues/734
@benwilson512 