### PR TITLE
Add support for brokered subscriptions

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -305,6 +305,7 @@ defmodule Absinthe.Plug do
 
   def subscribe(conn, topic, %{context: %{pubsub: pubsub}} = config) do
     pubsub.subscribe(topic)
+
     if config[:websocket_subscriptions] do
       conn
       |> put_resp_header("content-type", "text/event-stream")
@@ -312,7 +313,7 @@ defmodule Absinthe.Plug do
       |> subscribe_loop(topic, config)
     else
       conn
-      |> encode(200, %{ meta: %{ subscriptionId: topic } }, config)
+      |> encode(200, %{meta: %{subscriptionId: topic}}, config)
     end
   end
 


### PR DESCRIPTION
This is work in progress, for now I'm putting it up here only to start the conversation. This change goes along with https://github.com/absinthe-graphql/absinthe/pull/776

Like the changes in the other PR, this one is necessary to support message brokers for delivering subscription updates because obviously, updates aren't being sent through the WebSocket in that case (they are sent out-of-band through the broker instead.)

One question is how to encode the subscription ID in the HTTP response. GraphQL Ruby delivers the string `null` in the body with Content-Type `application/json` and sets the subscription ID in the `X-Subscription-ID` header.  At first I wanted to do it the same way for consistency, but doing so doesn't work well with one of my clients, Apollo iOS.  It chokes on the `null` (it wants a JSON body that is an object or an array), and more importantly it doesn't provide a good way to access the GraphQL response headers.

As far as I know, there is no standard for this and the GraphQL Ruby guys just made something up (?).  So unless there are any objections I'd prefer to just put the ID in the body instead.

(I've also come to think that it's slightly more consistent because the body is where any errors would come in, so by putting the ID in the body you don't have to look in two different places.)

Thoughts?
