### PR TITLE
Fix bug in variable decoding with bad input

### DIFF
--- a/lib/absinthe/plug/request/query.ex
+++ b/lib/absinthe/plug/request/query.ex
@@ -116,10 +116,7 @@ defmodule Absinthe.Plug.Request.Query do
   defp decode_variables("null", _), do: {:ok, %{}}
   defp decode_variables(nil, _), do: {:ok, %{}}
 
-  defp decode_variables(variables, _) when is_list(variables),
-    do: {:input_error, "Variables must be a map."}
-
-  defp decode_variables(variables, codec) do
+  defp decode_variables(variables, codec) when is_binary(variables) do
     case codec.module.decode(variables) do
       {:ok, results} ->
         {:ok, results}
@@ -128,6 +125,9 @@ defmodule Absinthe.Plug.Request.Query do
         {:input_error, "The variable values could not be decoded"}
     end
   end
+
+  defp decode_variables(_variables, _),
+    do: {:input_error, "Variables must be a map."}
 
   #
   # DOCUMENT

--- a/lib/absinthe/plug/request/query.ex
+++ b/lib/absinthe/plug/request/query.ex
@@ -116,6 +116,9 @@ defmodule Absinthe.Plug.Request.Query do
   defp decode_variables("null", _), do: {:ok, %{}}
   defp decode_variables(nil, _), do: {:ok, %{}}
 
+  defp decode_variables(variables, _) when is_list(variables),
+    do: {:input_error, "Variables must be a map."}
+
   defp decode_variables(variables, codec) do
     case codec.module.decode(variables) do
       {:ok, results} ->

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -24,6 +24,18 @@ defmodule Absinthe.PlugTest do
              |> Absinthe.Plug.call(opts)
   end
 
+  test "returns 400 with invalid variables structure" do
+    opts = Absinthe.Plug.init(schema: TestSchema)
+    body = Jason.encode!(%{query: @variable_query, variables: [%{id: 123}]})
+
+    assert %{status: 400} =
+             conn(:post, "/", body)
+             |> put_req_header("content-type", "application/json")
+             |> plug_parser
+             |> IO.inspect()
+             |> Absinthe.Plug.call(opts)
+  end
+
   @query """
   {
     item(id: "foo") {

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -32,7 +32,6 @@ defmodule Absinthe.PlugTest do
              conn(:post, "/", body)
              |> put_req_header("content-type", "application/json")
              |> plug_parser
-             |> IO.inspect()
              |> Absinthe.Plug.call(opts)
   end
 

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -24,9 +24,20 @@ defmodule Absinthe.PlugTest do
              |> Absinthe.Plug.call(opts)
   end
 
-  test "returns 400 with invalid variables structure" do
+  test "returns 400 with invalid variables list" do
     opts = Absinthe.Plug.init(schema: TestSchema)
     body = Jason.encode!(%{query: @variable_query, variables: [%{id: 123}]})
+
+    assert %{status: 400} =
+             conn(:post, "/", body)
+             |> put_req_header("content-type", "application/json")
+             |> plug_parser
+             |> Absinthe.Plug.call(opts)
+  end
+
+  test "returns 400 with invalid variables content" do
+    opts = Absinthe.Plug.init(schema: TestSchema)
+    body = Jason.encode!(%{query: @variable_query, variables: 7})
 
     assert %{status: 400} =
              conn(:post, "/", body)


### PR DESCRIPTION
This PR fixes a bug that arises when variables submitted in a `json` request are invalid: lists, numbers, etc.