### PR TITLE
Add Altair GraphQL interface.

### DIFF
--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -27,7 +27,7 @@ defmodule Absinthe.Plug.GraphiQL do
 
   Use the "altair" interface for Altair GraphQL instead:
 
-      forward "/graphiql",
+      forward "/altair",
         to: Absinthe.Plug.GraphiQL,
         init_opts: [
           schema: MyAppWeb.Schema,

--- a/lib/absinthe/plug/graphiql/altair_graphql.html.eex
+++ b/lib/absinthe/plug/graphiql/altair_graphql.html.eex
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Altair</title>
+  <base href="<%= assets["altair-static/base"] %>">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="<%= assets["altair-static/styles.css"] %>" rel="stylesheet" />
+</head>
+
+<body>
+  <app-root>
+    <style>
+      .loading-screen {
+        display: none;
+      }
+
+    </style>
+    <div class="loading-screen styled">
+      <div class="loading-screen-inner">
+        <div class="loading-screen-logo-container">
+          <img src="assets/img/logo_350.svg" alt="Altair">
+        </div>
+        <div class="loading-screen-loading-indicator">
+          <span class="loading-indicator-dot"></span>
+          <span class="loading-indicator-dot"></span>
+          <span class="loading-indicator-dot"></span>
+        </div>
+      </div>
+    </div>
+  </app-root>
+  <script rel="preload" as="script" type="text/javascript" src="<%= assets["altair-static/runtime.js"] %>"></script>
+  <script rel="preload" as="script" type="text/javascript" src="<%= assets["altair-static/polyfills.js"] %>"></script>
+  <script rel="preload" as="script" type="text/javascript" src="<%= assets["altair-static/main.js"] %>"></script>
+
+  <script>
+    var altairOptions = {};
+
+    <%= if default_url do %>
+      altairOptions.endpointURL = <%= default_url %>;
+    <% end %>
+
+    <%= if socket_url do %>
+      altairOptions.subscriptionsEndpoint = <%= socket_url %>;
+    <% end %>
+
+    <%= if query_string do %>
+      altairOptions.initialQuery = <%= query_string %>;
+    <% end %>
+
+    <%= if variables_string do %>
+      altairOptions.initialVariables = <%= variables_string %>;
+    <% end %>
+
+    window.addEventListener("load", function() {
+      AltairGraphQL.init(altairOptions);
+    });
+  </script>
+</body>
+
+</html>

--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -45,6 +45,14 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
        "graphiql-workspace.css",
        {"graphiql-workspace.min.js", "graphiql-workspace.js"}
      ]},
+    {"altair-static", "2.4.3",
+     [
+       {"build/dist/", "base"},
+       {"build/dist/styles.css", "styles.css"},
+       {"build/dist/runtime.js", "runtime.js"},
+       {"build/dist/polyfills.js", "polyfills.js"},
+       {"build/dist/main.js", "main.js"},
+     ]},
     # Used by graphql-playground
     {"typeface-source-code-pro", "0.0.44",
      [

--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -51,7 +51,7 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
        {"build/dist/styles.css", "styles.css"},
        {"build/dist/runtime.js", "runtime.js"},
        {"build/dist/polyfills.js", "polyfills.js"},
-       {"build/dist/main.js", "main.js"},
+       {"build/dist/main.js", "main.js"}
      ]},
     # Used by graphql-playground
     {"typeface-source-code-pro", "0.0.44",


### PR DESCRIPTION
This PR introduces the [Altair GraphQL](https://altair.sirmuel.design/) interface, as an alternative to GraphiQL and GraphQL playground.

Altair is a more fully featured alternative to the other options and has become a household name for working with GraphQL. It also seems to not suffer from issues affecting other tools (e.g. #199).

Please review and let me know what you think! 😊 