### PR TITLE
Remove duplicate struct key

### DIFF
--- a/lib/absinthe/plug/request/query.ex
+++ b/lib/absinthe/plug/request/query.ex
@@ -26,7 +26,6 @@ defmodule Absinthe.Plug.Request.Query do
     :adapter,
     :context,
     :schema,
-    document: nil,
     document_provider_key: nil,
     pipeline: [],
     document_provider: nil


### PR DESCRIPTION
Elixir 1.10 shows a compiler warning for duplicate key (see below)
Since a key is initialized with nil by default I removed
the `document: nil` entry.

```
==> absinthe_plug
Compiling 18 files (.ex)
warning: duplicate key :document found in struct
  (elixir 1.10.1) lib/kernel/utils.ex:119: Kernel.Utils.warn_on_duplicate_struct_key/1
  (elixir 1.10.1) lib/kernel/utils.ex:98: Kernel.Utils.defstruct/2
  lib/absinthe/plug/request/query.ex:19: (module)
  (elixir 1.10.1) src/elixir_compiler.erl:75: :elixir_compiler.dispatch/4
  (elixir 1.10.1) src/elixir_compiler.erl:60: :elixir_compiler.compile/3
```