### PR TITLE
Add helper to insert values into context

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -353,6 +353,36 @@ defmodule Absinthe.Plug do
     Plug.Conn.put_private(conn, :absinthe, Enum.into(opts, %{}))
   end
 
+  @doc """
+  Adds key-value pairs into Absinthe context.
+
+  ## Examples
+
+      iex> Absinthe.Plug.assign_context(conn, current_user: user)
+      %Plug.Conn{}
+  """
+  @spec assign_context(Plug.Conn.t(), Keyword.t() | map) :: Plug.Conn.t()
+  def assign_context(%Plug.Conn{private: %{absinthe: absinthe}} = conn, assigns) do
+    context =
+      absinthe
+      |> Map.get(:context, %{})
+      |> Map.merge(Map.new(assigns))
+
+    put_options(conn, context: context)
+  end
+
+  def assign_context(conn, assigns) do
+    put_options(conn, context: Map.new(assigns))
+  end
+
+  @doc """
+  Same as `assign_context/2` except one key-value pair is assigned.
+  """
+  @spec assign_context(Plug.Conn.t(), atom, any) :: Plug.Conn.t()
+  def assign_context(conn, key, value) do
+    assign_context(conn, [{key, value}])
+  end
+
   @doc false
   @spec execute(Plug.Conn.t(), map) :: {Plug.Conn.t(), any}
   def execute(conn, config) do

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -514,6 +514,46 @@ defmodule Absinthe.PlugTest do
     end
   end
 
+  describe "assign_context/2" do
+    test "with a pristine connection it sets the values as provided" do
+      conn =
+        conn(:post, "/")
+        |> Absinthe.Plug.assign_context(current_user: %{id: 1})
+
+      assert conn.private.absinthe.context.current_user.id == 1
+    end
+
+    test "doesn't wipe out previously set context if called twice" do
+      conn =
+        conn(:post, "/")
+        |> Absinthe.Plug.assign_context(current_user: %{id: 1})
+        |> Absinthe.Plug.assign_context(foo: "bar")
+
+      assert conn.private.absinthe.context.current_user.id == 1
+      assert conn.private.absinthe.context.foo == "bar"
+    end
+
+    test "values can be added individually" do
+      conn =
+        conn(:post, "/")
+        |> Absinthe.Plug.assign_context(:current_user, %{id: 1})
+        |> Absinthe.Plug.assign_context(:foo, "bar")
+
+      assert conn.private.absinthe.context.current_user.id == 1
+      assert conn.private.absinthe.context.foo == "bar"
+    end
+
+    test "values are merged properly" do
+      conn =
+        conn(:post, "/")
+        |> Absinthe.Plug.assign_context(current_user: %{id: 1}, foo: "bar")
+        |> Absinthe.Plug.assign_context(current_user: %{id: 2})
+
+      assert conn.private.absinthe.context.current_user.id == 2
+      assert conn.private.absinthe.context.foo == "bar"
+    end
+  end
+
   test "before_send with single query" do
     opts = Absinthe.Plug.init(schema: TestSchema, before_send: {__MODULE__, :test_before_send})
 


### PR DESCRIPTION
`Absinthe.Plug.put_options(conn, context: context)` overwrites any previously set context.

This pull request adds `assign_context` which merges values instead. This allows multiple plugs that configure context to be composed.

```elixir
conn
|> Absinthe.Plug.assign_context(current_user: current_user)
|> Absinthe.Plug.assign_context(foo: "bar")
```

I considered naming it `put_in_context` but conventionally `put` and `put_in` functions do not merge. Phoenix’s `assign` appears closest in behaviour.