### PR TITLE
Alternative schema validation check

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -227,15 +227,15 @@ defmodule Absinthe.Plug do
     default = Application.get_env(:absinthe, :schema)
     schema = Keyword.get(opts, :schema, default)
 
-    try do
-      Absinthe.Schema.types(schema)
-    rescue
-      UndefinedFunctionError ->
-        raise ArgumentError,
-              "The supplied schema: #{inspect(schema)} is not a valid Absinthe Schema"
-    end
+    valid_schema_module?(schema) ||
+      raise ArgumentError, "#{inspect(schema)} is not a valid `Absinthe.Schema`"
 
     schema
+  end
+
+  defp valid_schema_module?(schema) do
+    Code.ensure_loaded?(schema) &&
+      Absinthe.Schema in Keyword.get(schema.__info__(:attributes), :behaviour, [])
   end
 
   @doc false

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -233,9 +233,10 @@ defmodule Absinthe.Plug do
     schema
   end
 
-  defp valid_schema_module?(schema) do
-    Code.ensure_loaded?(schema) &&
-      Absinthe.Schema in Keyword.get(schema.__info__(:attributes), :behaviour, [])
+  defp valid_schema_module?(module) do
+    is_atom(module) &&
+      Code.ensure_loaded?(module) &&
+      Absinthe.Schema in Keyword.get(module.__info__(:attributes), :behaviour, [])
   end
 
   @doc false

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -573,16 +573,17 @@ defmodule Absinthe.PlugTest do
   defmodule NotaSchema do
   end
 
+  @message_matcher ~r/not a valid `Absinthe.Schema`/
   test "schema module validation checks" do
-    assert_raise ArgumentError, fn ->
+    assert_raise ArgumentError, @message_matcher, fn ->
       Absinthe.Plug.init(schema: :not_a_module)
     end
 
-    assert_raise ArgumentError, fn ->
+    assert_raise ArgumentError, @message_matcher, fn ->
       Absinthe.Plug.init(schema: NotaSchema)
     end
 
-    assert_raise ArgumentError, fn ->
+    assert_raise ArgumentError, @message_matcher, fn ->
       Absinthe.Plug.init(schema: "not even a module")
     end
   end

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -570,6 +570,23 @@ defmodule Absinthe.PlugTest do
     assert conn.private[:user_id] == 1
   end
 
+  defmodule NotaSchema do
+  end
+
+  test "schema module validation checks" do
+    assert_raise ArgumentError, fn ->
+      Absinthe.Plug.init(schema: :not_a_module)
+    end
+
+    assert_raise ArgumentError, fn ->
+      Absinthe.Plug.init(schema: NotaSchema)
+    end
+
+    assert_raise ArgumentError, fn ->
+      Absinthe.Plug.init(schema: "not even a module")
+    end
+  end
+
   def test_before_send(conn, val) do
     # just for easy testing
     send(self(), {:before_send, val})


### PR DESCRIPTION
When a schema is using `persistent_term` backend, asking for the `types` during compile time will cause an exception since they haven't been populated yet.

This PR provides an alternative validation check that verifies if the atom is a module and if that module implements the `Absinthe.Schema` behavior.
