### PR TITLE
Fix schema valid check

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -239,9 +239,13 @@ defmodule Absinthe.Plug do
   end
 
   defp valid_schema_module?(module) do
-    is_atom(module) &&
-      Code.ensure_loaded?(module) &&
-      Absinthe.Schema in Keyword.get(module.__info__(:attributes), :behaviour, [])
+    with true <- is_atom(module),
+         {:module, _} <- Code.ensure_compiled(module),
+         true <- Absinthe.Schema in Keyword.get(module.__info__(:attributes), :behaviour, []) do
+      true
+    else
+      _ -> false
+    end
   end
 
   @doc false

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -584,7 +584,7 @@ defmodule Absinthe.PlugTest do
     end
 
     assert_raise ArgumentError, @message_matcher, fn ->
-      Absinthe.Plug.init(schema: "not even a module")
+      Absinthe.Plug.init(schema: "not even an atom")
     end
   end
 


### PR DESCRIPTION
This PR tweaks the schema validation check to make sure the schema module is compiled before completing the check.

Fixes #239 