### PR TITLE
Make absinthe version less restrictive so you can upgrade absinthe

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install from [Hex.pm](https://hex.pm/packages/absinthe_plug):
 
 ```elixir
 def deps do
-  [{:absinthe_plug, "~> 1.5.0"}]
+  [{:absinthe_plug, "~> 1.5"}]
 end
 ```
 
@@ -26,7 +26,7 @@ end
 def deps do
   [
     ...,
-    {:absinthe_plug, "~> 1.5.0"},
+    {:absinthe_plug, "~> 1.5"},
     {:jason, "~> 1.0"}
   ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Absinthe.Plug.Mixfile do
   defp deps do
     [
       {:plug, "~> 1.3.2 or ~> 1.4"},
-      {:absinthe, "~> 1.5.0"},
+      {:absinthe, "~> 1.5"},
       {:jason, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.20", only: :dev}
     ]


### PR DESCRIPTION
Otherwise you'd have to `{:absinthe, "~> 1.6.0", override: true},` in your app.
The `~> 1.5` allows for 1.5, 1.6, 1.7, 1.8 ...