### PR TITLE
Set all plug options via put_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.4
+
+- Feature: [Set all plug options via put_options](https://github.com/absinthe-graphql/absinthe_plug/pull/243)
+
 ## v1.5.3
 
 - Chore: [Loosen Absinthe version](https://github.com/absinthe-graphql/absinthe_plug/pull/242)

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -299,6 +299,12 @@ defmodule Absinthe.Plug do
   end
 
   defp update_config(conn, config) do
+    config
+    |> update_pubsub(conn)
+    |> update_raw_options(conn)
+  end
+
+  defp update_pubsub(config, conn) do
     pubsub = config[:pubsub] || config.context[:pubsub] || conn.private[:phoenix_endpoint]
 
     if pubsub do
@@ -306,6 +312,15 @@ defmodule Absinthe.Plug do
     else
       config
     end
+  end
+
+  defp update_raw_options(config, %{private: %{absinthe: absinthe}}) do
+    raw_options = Map.take(absinthe, @raw_options) |> Map.to_list()
+    update_in(config.raw_options, &Keyword.merge(&1, raw_options))
+  end
+
+  defp update_raw_options(config, _conn) do
+    config
   end
 
   def subscribe(conn, topic, %{context: %{pubsub: pubsub}} = config) do

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -512,6 +512,33 @@ defmodule Absinthe.PlugTest do
       assert conn.private.absinthe.context.current_user.id == 1
       assert conn.private.absinthe.root_value.field_on_root_value == "foo"
     end
+
+    test "set complexity" do
+      opts = Absinthe.Plug.init(schema: TestSchema)
+
+      query = "{expensive}"
+
+      assert %{status: 200, resp_body: resp_body} =
+               conn(:post, "/", Jason.encode!(%{"query" => query}))
+               |> Absinthe.Plug.put_options(analyze_complexity: true, max_complexity: 100)
+               |> put_req_header("content-type", "application/json")
+               |> call(opts)
+
+      expected = %{
+        "errors" => [
+          %{
+            "locations" => [%{"column" => 2, "line" => 1}],
+            "message" => "Field expensive is too complex: complexity is 1000 and maximum is 100"
+          },
+          %{
+            "locations" => [%{"column" => 1, "line" => 1}],
+            "message" => "Operation is too complex: complexity is 1000 and maximum is 100"
+          }
+        ]
+      }
+
+      assert expected == resp_body
+    end
   end
 
   describe "assign_context/2" do

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -513,14 +513,17 @@ defmodule Absinthe.PlugTest do
       assert conn.private.absinthe.root_value.field_on_root_value == "foo"
     end
 
-    test "set complexity" do
+    test "sets complexity" do
       opts = Absinthe.Plug.init(schema: TestSchema)
 
       query = "{expensive}"
 
       assert %{status: 200, resp_body: resp_body} =
                conn(:post, "/", Jason.encode!(%{"query" => query}))
-               |> Absinthe.Plug.put_options(analyze_complexity: true, max_complexity: 100)
+               |> Absinthe.Plug.put_options(
+                 analyze_complexity: true,
+                 max_complexity: 100
+               )
                |> put_req_header("content-type", "application/json")
                |> call(opts)
 
@@ -538,6 +541,23 @@ defmodule Absinthe.PlugTest do
       }
 
       assert expected == resp_body
+    end
+
+    test "sets all init options" do
+      opts = Absinthe.Plug.init(schema: TestSchema)
+      query = ""
+
+      assert %{resp_body: resp_body, resp_headers: resp_headers} =
+               conn(:post, "/", Jason.encode!(%{"query" => query}))
+               |> Absinthe.Plug.put_options(
+                 no_query_message: "No query!!",
+                 content_type: "text/who-knows"
+               )
+               |> put_req_header("content-type", "application/json")
+               |> call(opts)
+
+      assert %{"errors" => [%{"message" => "No query!!"}]} = resp_body
+      assert {"content-type", "text/who-knows; charset=utf-8"} in resp_headers
     end
   end
 


### PR DESCRIPTION
This PR wires up the ability to set complexity settings via `put_options`

@benwilson512 These make sense to set on a per-request basis, but I'm not sure if the other options do...

closes #241 