### PR TITLE
updated project list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See [HexDocs](https://hexdocs.pm/absinthe_plug).
 
 ## Related Projects
 
-See the project list at <http://absinthe-graphql.org/projects>.
+See the project list at <https://github.com/absinthe-graphql>.
 
 ## License
 


### PR DESCRIPTION
Not sure where the project list link should go to, but the current location results in a 404.