### PR TITLE
Fix update_config bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.5
+
+- Bug Fix: [Don't wipe out an existing pubsub value in context](https://github.com/absinthe-graphql/absinthe_plug/pull/249)
+
 ## v1.5.4
 
 - Feature: [Set all plug options via put_options](https://github.com/absinthe-graphql/absinthe_plug/pull/243)

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -320,11 +320,12 @@ defmodule Absinthe.Plug do
     end
   end
 
-  defp update_config(conn, config) do
+  @doc false
+  def update_config(conn, config) do
     config
-    |> update_config(:pubsub, conn)
     |> update_config(:raw_options, conn)
     |> update_config(:init_options, conn)
+    |> update_config(:pubsub, conn)
   end
 
   defp update_config(config, :pubsub, conn) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Absinthe.Plug.Mixfile do
   use Mix.Project
 
-  @version "1.5.4"
+  @version "1.5.5"
 
   def project do
     [

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -559,6 +559,19 @@ defmodule Absinthe.PlugTest do
       assert %{"errors" => [%{"message" => "No query!!"}]} = resp_body
       assert {"content-type", "text/who-knows; charset=utf-8"} in resp_headers
     end
+
+    test "don't wipe out pubsub" do
+      config = Absinthe.Plug.init(schema: TestSchema, context: %{user_id: 1})
+
+      conn =
+        conn(:post, "/")
+        |> Absinthe.Plug.put_options(pubsub: PubSub)
+
+      updated_config = Absinthe.Plug.update_config(conn, config)
+
+      assert updated_config.context.pubsub == PubSub
+      assert updated_config.context.user_id == 1
+    end
   end
 
   describe "assign_context/2" do


### PR DESCRIPTION
This PR fixes a bug in the `update_config` function so that it doesn't stomp any existing values in the `context`

Fixes #247 