### PR TITLE
Preserve :context init option if conn.private[:absinthe][:context] is set

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -126,7 +126,6 @@ defmodule Absinthe.Plug do
 
   @init_options [
     :adapter,
-    :context,
     :no_query_message,
     :json_codec,
     :pipeline,

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -482,6 +482,38 @@ defmodule Absinthe.PlugTest do
     assert Enum.member?(events, %{"data" => %{"update" => "BAR"}})
   end
 
+  @query """
+  query GetUser {
+    user
+  }
+  """
+
+  test "Context init options are preserved if conn.private[:absinthe][:context] is set" do
+    opts = Absinthe.Plug.init(schema: TestSchema, context: %{user: "Foo"})
+
+    assert %{status: 200, resp_body: resp_body} =
+             conn(:post, "/", %{"query" => @query})
+             |> Absinthe.Plug.assign_context(foo: "bar")
+             |> put_req_header("content-type", "application/json")
+             |> plug_parser
+             |> Absinthe.Plug.call(opts)
+
+    assert resp_body == ~s({"data":{"user":"Foo"}})
+  end
+
+  test "Context init options are merged with conn.private[:absinthe][:context]" do
+    opts = Absinthe.Plug.init(schema: TestSchema, context: %{foo: "bar"})
+
+    assert %{status: 200, resp_body: resp_body} =
+             conn(:post, "/", %{"query" => @query})
+             |> Absinthe.Plug.assign_context(user: "Foo")
+             |> put_req_header("content-type", "application/json")
+             |> plug_parser
+             |> Absinthe.Plug.call(opts)
+
+    assert resp_body == ~s({"data":{"user":"Foo"}})
+  end
+
   describe "put_options/2" do
     test "with a pristine connection it sets the values as provided" do
       conn =

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -39,13 +39,12 @@ defmodule Absinthe.Plug.TestSchema do
     end
 
     field :user, :string do
-      resolve fn _,
-                 %{
-                   context: %{
-                     user: user
-                   }
-                 } ->
-        {:ok, user}
+      resolve fn
+        _, %{context: %{user: user}} ->
+          {:ok, user}
+
+        _, %{context: %{}} ->
+          {:error, "User is missing in context"}
       end
     end
 


### PR DESCRIPTION
Hi there. I've stumbled upon a problem in `absinthe_plug` I'd like to propose a fix for.

### Description of the Problem

If `Absinthe.Plug` is initialized with a `:context` option and some other plug puts something inside `conn.private[:absinthe][:context]`, either directly or by using the helper functions `Absinthe.Plug.assign_context/2` or `Absinthe.Plug.put_options/2`, the values from the initialization are overwritten by the latter. This is a result from `Absinthe.Plug.update_config(:init_options, conn)` merging the options, but not doing a deep merge. 

### Proposed Solution

In fact to me it looks like the `:context` config field is merged in [`Absinthe.Plug.Request.parse/2`](https://github.com/absinthe-graphql/absinthe_plug/blob/master/lib/absinthe/plug/request.ex#L32), so there's no need to also do that in `Absinthe.Plug`. I've therefore removed `:context` from the `@init_options` list.

### Tests

My pull request comes with two tests. The first one fails without my fix. The second one is a sanitary check that asserts the two representations are actually merged. 