### PR TITLE
Improve Github Actions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -15,11 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          - elixir: '1.11'
-            otp: '23'
-          - elixir: '1.10'
-            otp: '22'
+        elixir:
+          - '1.10'
+          - '1.11'
+        otp:
+          - '22'
+          - '23'
 
     steps:
     - name: Checkout
@@ -34,24 +33,24 @@ jobs:
     - name: Restore deps cache
       uses: actions/cache@v2
       with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        path: |
+          deps
+          _build
+        key: ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}
+          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}
 
-    - name: Restore _build cache
-      uses: actions/cache@v2
-      with:
-        path: _build
-        key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
-
-    - name: Install deps
+    - name: Install package dependencies
       run: mix deps.get
 
-    - name: Check Formatting
+    - name: Check code format
       run: mix format --check-formatted
+
+    - name: Compile dependencies
+      run: mix compile
+      env:
+        MIX_ENV: test
 
     - name: Run unit tests
       run: mix test

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Absinthe.Plug.Mixfile do
     [
       app: :absinthe_plug,
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.10",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
Hello.

It looks like commiting to branches excluding master does not run Github Actions. So users which are working on feature/bugfix branches cannot see that their changes are leading to failed tests until they'll create a pull request to master branch.
So I've removed restriction against branch name for push events.

Also I've found another quite annoying bug - step actions/cache does not update cache item if it was restored using a primary key.
For example, some dependencies like dialyzer or other ones store their files in deps or _build folders (which are cached in the workflow). But when these dependencies perform some updates of these folders, it does not lead to the updating of mix.lock file. File hasn't been changed -> hash is the same -> cache primary key is the same -> caching action will not update the existing cache.
This will cause the increase of workflow run time because the stored cache will not be used by some steps. Until mix.lock will be updated which will lead to updating the cache item.
Here I've appended a commit SHA to the cache primary key, so it will always be updated. But it will not affect cache reading.

What do you think about that?

