### PR TITLE
Handle invalid batch request structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.6
+
+- Bug Fix: [Handle invalid batch request structure](https://github.com/absinthe-graphql/absinthe_plug/pull/255)
+
 ## v1.5.5
 
 - Bug Fix: [Don't wipe out an existing pubsub value in context](https://github.com/absinthe-graphql/absinthe_plug/pull/249)

--- a/lib/absinthe/plug/request.ex
+++ b/lib/absinthe/plug/request.ex
@@ -56,6 +56,7 @@ defmodule Absinthe.Plug.Request do
   # Plug puts parsed params under the "_json" key when the
   # structure is not a map; otherwise it's just the keys themselves,
   # and they may sit in the body or in the params
+
   defp is_batch?(params) do
     Map.has_key?(params, "_json") && is_list(params["_json"])
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Absinthe.Plug.Mixfile do
   use Mix.Project
 
-  @version "1.5.5"
+  @version "1.5.6"
 
   def project do
     [

--- a/test/lib/absinthe/plug/transport_batching_test.exs
+++ b/test/lib/absinthe/plug/transport_batching_test.exs
@@ -441,6 +441,19 @@ defmodule Absinthe.Plug.TransportBatchingTest do
     assert conn.private[:user_id] == 1
   end
 
+  test "returns 400 with invalid batch structure" do
+    opts = Absinthe.Plug.init(schema: TestSchema)
+
+    # list of query strings is invalid
+    body = Jason.encode!(["{ item { name } }"])
+
+    assert %{status: 400} =
+             conn(:post, "/", body)
+             |> put_req_header("content-type", "application/json")
+             |> plug_parser
+             |> Absinthe.Plug.call(opts)
+  end
+
   def test_before_send(conn, val) do
     # just for easy testing
     send(self(), {:before_send, val})


### PR DESCRIPTION
This PR fixes a bug when a user submits a transport batch request with a certain invalid request structure - a list of query strings instead of a list of objects with a `query` key