### PR TITLE
Preserve :context during init

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -126,7 +126,6 @@ defmodule Absinthe.Plug do
 
   @init_options [
     :adapter,
-    :context,
     :no_query_message,
     :json_codec,
     :pipeline,

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -126,6 +126,7 @@ defmodule Absinthe.Plug do
 
   @init_options [
     :adapter,
+    :context,
     :no_query_message,
     :json_codec,
     :pipeline,
@@ -325,6 +326,7 @@ defmodule Absinthe.Plug do
     |> update_config(:raw_options, conn)
     |> update_config(:init_options, conn)
     |> update_config(:pubsub, conn)
+    |> update_config(:context, conn)
   end
 
   defp update_config(config, :pubsub, conn) do
@@ -343,7 +345,11 @@ defmodule Absinthe.Plug do
   end
 
   defp update_config(config, :init_options, %{private: %{absinthe: absinthe}}) do
-    Map.merge(config, Map.take(absinthe, @init_options -- @raw_options))
+    Map.merge(config, Map.take(absinthe, @init_options -- [:context | @raw_options]))
+  end
+
+  defp update_config(config, :context, %{private: %{absinthe: %{context: context}}}) do
+    update_in(config.context, &Map.merge(&1, context))
   end
 
   defp update_config(config, _, _conn) do

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -482,6 +482,38 @@ defmodule Absinthe.PlugTest do
     assert Enum.member?(events, %{"data" => %{"update" => "BAR"}})
   end
 
+  @query """
+  query GetUser {
+    user
+  }
+  """
+
+  test "Context init options are preserved if conn.private[:absinthe][:context] is set" do
+    opts = Absinthe.Plug.init(schema: TestSchema, context: %{user: "Foo"})
+
+    assert %{status: 200, resp_body: resp_body} =
+             conn(:post, "/", %{"query" => @query})
+             |> Absinthe.Plug.assign_context(foo: "bar")
+             |> put_req_header("content-type", "application/json")
+             |> plug_parser
+             |> Absinthe.Plug.call(opts)
+
+    assert resp_body == ~s({"data":{"user":"Foo"}})
+  end
+
+  test "Context init options are merged with conn.private[:absinthe][:context]" do
+    opts = Absinthe.Plug.init(schema: TestSchema, context: %{foo: "bar"})
+
+    assert %{status: 200, resp_body: resp_body} =
+             conn(:post, "/", %{"query" => @query})
+             |> Absinthe.Plug.assign_context(user: "Foo")
+             |> put_req_header("content-type", "application/json")
+             |> plug_parser
+             |> Absinthe.Plug.call(opts)
+
+    assert resp_body == ~s({"data":{"user":"Foo"}})
+  end
+
   describe "put_options/2" do
     test "with a pristine connection it sets the values as provided" do
       conn =

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -609,7 +609,7 @@ defmodule Absinthe.PlugTest do
       config = Absinthe.Plug.init(schema: TestSchema, context: %{user: "Foo"})
 
       conn =
-        conn(:post, "/", %{"query" => @query})
+        conn(:post, "/")
         |> Absinthe.Plug.assign_context(foo: "bar")
 
       updated_config = Absinthe.Plug.update_config(conn, config)

--- a/test/lib/absinthe/plug_test.exs
+++ b/test/lib/absinthe/plug_test.exs
@@ -604,6 +604,19 @@ defmodule Absinthe.PlugTest do
       assert updated_config.context.pubsub == PubSub
       assert updated_config.context.user_id == 1
     end
+
+    test "don't wipe out context" do
+      config = Absinthe.Plug.init(schema: TestSchema, context: %{user: "Foo"})
+
+      conn =
+        conn(:post, "/", %{"query" => @query})
+        |> Absinthe.Plug.assign_context(foo: "bar")
+
+      updated_config = Absinthe.Plug.update_config(conn, config)
+
+      assert updated_config.context.foo == "bar"
+      assert updated_config.context.user == "Foo"
+    end
   end
 
   describe "assign_context/2" do

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -39,13 +39,12 @@ defmodule Absinthe.Plug.TestSchema do
     end
 
     field :user, :string do
-      resolve fn _,
-                 %{
-                   context: %{
-                     user: user
-                   }
-                 } ->
-        {:ok, user}
+      resolve fn
+        _, %{context: %{user: user}} ->
+          {:ok, user}
+
+        _, %{context: %{}} ->
+          {:error, "User is missing in context"}
       end
     end
 


### PR DESCRIPTION
This PR ensures we merge the `:context` if it's both initialized and later added to in a plug.

Replaces #251 