### PR TITLE
Handle "unavailable" schema module status more correctly

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -260,12 +260,16 @@ defmodule Absinthe.Plug do
     schema
   end
 
-  defp valid_schema_module?(module) do
+  defp valid_schema_module?(module, retries \\ 0) do
     with true <- is_atom(module),
          {:module, _} <- Code.ensure_compiled(module),
          true <- Absinthe.Schema in Keyword.get(module.__info__(:attributes), :behaviour, []) do
       true
     else
+      {:error, :unavailable} when retries < 100 ->
+        Process.sleep(100)
+        valid_schema_module?(module, retries + 1)
+
       _ -> false
     end
   end


### PR DESCRIPTION
I've been dancing around these unpredictable "is not a valid `Absinthe.Schema`" errors for months now, and finally took some time to figure out exactly what's going on. It turns out that when checking the validity of the schema with `Code.ensure_compiled/1`, it's possible that the module is not available _yet_, but _may_ be later. We don't currently handle that condition, so if the compiler hits a particular race condition, the schema is simply rejected. This little tweak seems to fix my issues completely :)

The Elixir documentation specifies for Code.ensure_compiled/1 that
{:error, :unavailable} is not necessarily an error condition, as the
deadlock could still be broken by the compiler. So we give the compiler
a little time to break the deadlock and retry a number of times before
we give up.