### PR TITLE
Chore: Upgrade GraphiQL to 1.11.4

### DIFF
--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -11,7 +11,7 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
     remote_source: "https://cdn.jsdelivr.net/npm/:package@:version/:file"
   ]
 
-  @react_version "15.6.1"
+  @react_version "16.13.1"
 
   @assets [
     {"whatwg-fetch", "2.0.3",
@@ -20,9 +20,17 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
      ]},
     {"react", @react_version,
      [
-       {"dist/react.min.js", "react.js"}
+       {"umd/react.production.min.js", "react.js"}
      ]},
     {"react-dom", @react_version,
+     [
+       {"umd/react-dom.production.min.js", "react-dom.js"}
+     ]},
+    {"react15", "15.4.2",
+     [
+       {"dist/react.min.js", "react.js"}
+     ]},
+    {"react15-dom", "15.4.2",
      [
        {"dist/react-dom.min.js", "react-dom.js"}
      ]},
@@ -35,7 +43,7 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
        {"dist/fonts/glyphicons-halflings-regular.svg", "fonts/glyphicons-halflings-regular.svg"},
        {"dist/css/bootstrap.min.css", "css/bootstrap.css"}
      ]},
-    {"graphiql", "0.11.10",
+    {"graphiql", "1.11.4",
      [
        "graphiql.css",
        {"graphiql.min.js", "graphiql.js"}
@@ -132,6 +140,14 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
     build_asset_path(:remote_source, asset)
   end
 
+  defp build_asset_path(:remote_source, {package, version, {real_path, aliased_path}}) do
+    assets_config()[:remote_source]
+    |> String.replace(":package", get_package_name(package))
+    |> String.replace(":version", version)
+    |> String.replace(":file", real_path)
+    |> String.replace(":alias", aliased_path)
+  end
+
   defp build_asset_path(source, {package, version, {real_path, aliased_path}}) do
     assets_config()[source]
     |> String.replace(":package", package)
@@ -142,5 +158,11 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
 
   defp build_asset_path(source, {package, version, path}) do
     build_asset_path(source, {package, version, {path, path}})
+  end
+
+  def get_package_name(name) do
+    if Enum.member?(["react15", "react15-dom", "graphiql-beta"], name),
+      do: String.replace(name, "15", "") |> String.replace("-beta", ""),
+      else: name
   end
 end

--- a/lib/absinthe/plug/graphiql/graphiql_workspace.html.eex
+++ b/lib/absinthe/plug/graphiql/graphiql_workspace.html.eex
@@ -19,8 +19,8 @@ add "&raw" to the end of the URL within a browser.
 </head>
 <body>
   <div id="root" class="graphiql-workspace"></div>
-  <script src="<%= assets["react/react.js"] %>"></script>
-  <script src="<%= assets["react-dom/react-dom.js"] %>"></script>
+  <script src="<%= assets["react15/react.js"] %>"></script>
+  <script src="<%= assets["react15-dom/react-dom.js"] %>"></script>
   <script src="<%= assets["graphiql-workspace/graphiql-workspace.js"] %>"></script>
   <script src="<%= assets["@absinthe/socket-graphiql/socket-graphiql.js"] %>"></script>
   <script type="text/javascript">


### PR DESCRIPTION
So, this is the first step on a bigger journey to get the GraphiQL client(s) up to date.

I might need little guidance here and there since I only started wokring with the codebase this evening, and not everything might be optimal ( looking at you, `build_asset_path/2`)

I also have s semi-functional version of graphiql 2.0 behind a new `:beta` interface key, but that one needs some more work to get headers to work, and to figure out whether we still need the @absinthe/absinthe-socket` libs or whether `createGraphiQLFetcher()` from `@graphiql/toolkit` can solve whatever prompted the creation of that in the first place out of the box now.

<img width="1694" alt="Screenshot 2022-08-16 at 04 53 30" src="https://user-images.githubusercontent.com/7240688/184788334-48f6749f-da3d-48df-a37c-e54eb50ce90b.png">

If someone has more context/knows, why some decisions were made, that would be greatly appreciated!

## This PR
the package still used the 5 year old `graphiql@0.11.10`, which has a bunch of security issues and could benefit from an update in general (bundle size reduction from `react@16` among others). This PR updates graphiql and introduces a way to have two react versions in the asset list, so graphiql-workspace(the `:advanced` interface) stays functional, since it break with newer react versions.

## Next Steps
The next big step would be to get `graphiql@2` working, especially with headers and subscriptions. The is quite a bit of plumbing going on atm, which I will need to figure out first, plus the new `createGraphiQLFetcher` function is not shipped in a browser-compatible version, so we might need another intermediary package... 😨 

Once 2.0 ships and graduates beta stage, we can probably remove/alias the :advanced` interface, since graphiql provides those enhancements out of the box. Also, `graphiql-workspace` hasn't seen an update in ~4 years, so I wouldn't expect and update on that front.

Happy about any and all feedback !

