### PR TITLE
Switch to Application.compile_env/3

### DIFF
--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -2,7 +2,7 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
   @moduledoc """
   """
 
-  @config Application.get_env(:absinthe_plug, Absinthe.Plug.GraphiQL)
+  @config Application.compile_env(:absinthe_plug, Absinthe.Plug.GraphiQL)
   @default_config [
     source: :smart,
     local_url_path: "/absinthe_graphiql",


### PR DESCRIPTION
It gets rid of this warning:

```
==> absinthe_plug
Compiling 18 files (.ex)
warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/absinthe/plug/graphiql/assets.ex:5: Absinthe.Plug.GraphiQL.Assets
```
  
Since we are requiring `~> 1.10` version of Elixir, this change should be alright.