### PR TITLE
Ensure module is loaded when fetching default_url

### DIFF
--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -437,6 +437,8 @@ defmodule Absinthe.Plug.GraphiQL do
   defp get_config_val(config, key, conn) do
     case Map.get(config, key) do
       {module, fun} when is_atom(fun) ->
+        Code.ensure_loaded(module)
+
         case function_arity(module, fun) do
           1 ->
             apply(module, fun, [conn])

--- a/test/lib/absinthe/graphiql_test.exs
+++ b/test/lib/absinthe/graphiql_test.exs
@@ -165,6 +165,25 @@ defmodule Absinthe.Plug.GraphiQLTest do
            )
   end
 
+  test "default_url module is loaded" do
+    module = "Elixir.GraphiQLDefaultUrl" |> String.to_atom()
+
+    opts =
+      Absinthe.Plug.GraphiQL.init(
+        schema: TestSchema,
+        default_url: {module, :graphiql_default_url}
+      )
+
+    assert %{status: status, resp_body: body} =
+             conn(:get, "/")
+             |> plug_parser
+             |> put_req_header("accept", "text/html")
+             |> Absinthe.Plug.GraphiQL.call(opts)
+
+    assert 200 == status
+    assert String.contains?(body, "defaultUrl: '#{graphiql_default_url()}'")
+  end
+
   test "socket_url option works a function of arity 0" do
     opts =
       Absinthe.Plug.GraphiQL.init(

--- a/test/support/graphiql_default_url.ex
+++ b/test/support/graphiql_default_url.ex
@@ -1,0 +1,3 @@
+defmodule GraphiQLDefaultUrl do
+  def graphiql_default_url(), do: "https://api.foobarbaz.test"
+end


### PR DESCRIPTION
We've run into an issue recently when we were getting `** (RuntimeError) function for default_url: {Elixir.MyModule, graphiql_default_url} is not exported with arity 1 or 0` error. Both the module and the function did exist. After investigation, it turned out that for some reason by the time `absinthe_plug`  was calling `function_exported?` the module was not loaded and `function_exported?` [does not do this automatically](function_exported?).

So I believe it's worth loading the module explicitly. I also added a test which is a bit clunky, so if you know a better way to create an unloaded module please let me know!