### PR TITLE
Rescue exceptions, raise Plug.Conn.WrapperError

### DIFF
--- a/test/lib/absinthe/plug/document_provider_test.exs
+++ b/test/lib/absinthe/plug/document_provider_test.exs
@@ -50,7 +50,7 @@ defmodule Absinthe.Plug.DocumentProviderTest do
 
   test "cannot process without any document providers" do
     opts = Absinthe.Plug.init(schema: TestSchema, document_providers: [])
-    assert_raise RuntimeError, fn -> request(opts) end
+    assert_raise Plug.Conn.WrapperError, fn -> request(opts) end
   end
 
   defp request(opts) do


### PR DESCRIPTION
We have a Phoenix application that expects the `[:phoenix, :endpoint, :stop]` event to be executed, but I noticed that this was not happening when uncaught exceptions originated from this plug.

This is because `Plug.Telemetry` [registers this event](https://github.com/elixir-plug/plug/blob/63ddce30077d58470215f2aba9eb3ca9f7416140/lib/plug/telemetry.ex#L74) by using `Plug.Conn.register_before_send`, which, in turn, adds a key to `conn.private`.

When there is an uncaught exception, Phoenix catches the error to render a standard error response [here](https://github.com/phoenixframework/phoenix/blob/53d36bc63013d9a84040bf811ff01c07c8c7e040/lib/phoenix/endpoint/render_errors.ex#L38).

Notice that if there is a `Plug.Conn.WrapperError`, the `conn` from it is used, but if not, `conn` is what's in scope at the time the `RenderErrors` plug runs. This happens to be at the top of the middleware stack before `Plug.Telemetry` registers the callback. Thus, no `[:phoenix, :endpoint, :stop]` event is executed. 

Note also that bug reporting plugs may also expect request parsers etc. to have surfaced important bits of info on the `conn` (we ran into this issue as well, but worked around it).

This issue can be solved by rescuing errors in `call` and using `Plug.Conn.Wrapper.reraise/4`
