### PR TITLE
Add token limit to init and raw options

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -139,11 +139,13 @@ defmodule Absinthe.Plug do
     :pubsub,
     :analyze_complexity,
     :max_complexity,
+    :token_limit,
     :transport_batch_payload_key
   ]
   @raw_options [
     :analyze_complexity,
-    :max_complexity
+    :max_complexity,
+    :token_limit
   ]
 
   @type function_name :: atom
@@ -163,6 +165,7 @@ defmodule Absinthe.Plug do
   - `:pubsub` -- (Optional) Pub Sub module for Subscriptions.
   - `:analyze_complexity` -- (Optional) Set whether to calculate the complexity of incoming GraphQL queries.
   - `:max_complexity` -- (Optional) Set the maximum allowed complexity of the GraphQL query. If a document’s calculated complexity exceeds the maximum, resolution will be skipped and an error will be returned in the result detailing the calculated and maximum complexities.
+  - `:token_limit` -- (Optional) Set a limit on the number of allowed parseable tokens in the GraphQL query. Queries with exceedingly high token counts can be expensive to parse. If a query's token count exceeds the set limit, an error will be returned during Absinthe parsing (default: `:infinity`).
   - `:transport_batch_payload_key` -- (Optional) Set whether or not to nest Transport Batch request results in a `payload` key. Older clients expected this key to be present, but newer clients have dropped this pattern. (default: `true`)
 
   """
@@ -179,6 +182,7 @@ defmodule Absinthe.Plug do
             | {module, atom},
           analyze_complexity: boolean,
           max_complexity: non_neg_integer | :infinity,
+          token_limit: non_neg_integer | :infinity,
           serializer: module | {module, Keyword.t()},
           content_type: String.t(),
           before_send: {module, atom},


### PR DESCRIPTION
Hello! This is a small amount of follow-up work to my teammate's (@stellanor) addition of token limiting in Absinthe. Here is that prior context: https://github.com/absinthe-graphql/absinthe/pull/1210

This work adds the new `token_limit` option so that we can leverage the new ability in Absinthe. I have tested this locally with our own service against the current master branch of Absinthe to verify the value is passed along as expected, but as of opening this PR, I haven't added an integration test for this; I believe we'd need to upgrade the Absinthe dependency to the current master branch (so that the effects of token limiting are present) in order to do so. Then again, the value does behave the same way/follow the same flow as `max_complexity`, so I'm also wondering if a dedicated test is necessary. The token limiting feature itself is fully tested in Absinthe.

I'm happy to receive any feedback/requests to get functionality this added in, thank you!