### PR TITLE
Added Apollo's Explorer Sandbox interface

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,9 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
+
+# `Mix.Config` is deprecated since elixir's version v1.12.3.
+# @TODO: Replace `use Mix.Config` for `import Config` on v2 release and bump
+#        Elixir's minimum version to v1.12.3.
 use Mix.Config
 
 # This configuration is loaded before any dependency and is restricted

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -36,7 +36,17 @@ defmodule Absinthe.Plug do
         to: Absinthe.Plug.GraphiQL,
         init_opts: [schema: MyAppWeb.Schema]
 
-  For more information, see the API documentation for `Absinthe.Plug`.
+  To specifywhat GraphiQL interface should be used, you may add the `:interface`
+  to `init_opts`:
+
+      forward "/graphiql",
+        to: Absinthe.Plug.GraphiQL,
+        init_opts: [
+          schema: MyAppWeb.Schema,
+          interface: :apollo_explorer_sandbox
+        ]
+
+  For more information, see the API documentation for `Absinthe.Plug` and `Absinthe.Plug.GraphiQL`.
 
   ### Phoenix.Router
 

--- a/lib/absinthe/plug/graphiql/apollo_explorer_sandbox.html.eex
+++ b/lib/absinthe/plug/graphiql/apollo_explorer_sandbox.html.eex
@@ -1,0 +1,39 @@
+<!--
+See https://www.apollographql.com/docs/graphos/explorer/sandbox/#embedding-sandbox
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>Apollo Explorer Sandbox</title>
+
+  <style>
+    /**
+     * The new CSS reset - version 1.8.4 (last updated 14.2.2023)
+     * GitHub page: https://github.com/elad2412/the-new-css-reset
+     */
+    *:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {all: unset;display: revert;}*, *::before, *::after {box-sizing: border-box;}a, button {cursor: revert;}ol, ul, menu {list-style: none;}img {max-inline-size: 100%;max-block-size: 100%;}table {border-collapse: collapse;}input, textarea {-webkit-user-select: auto;}textarea {white-space: revert;}meter {-webkit-appearance: revert;appearance: revert;}:where(pre) {all: revert;}::placeholder {color: unset;}::marker {content: initial;}:where([hidden]) {display: none;}:where([contenteditable]:not([contenteditable="false"])) {-moz-user-modify: read-write;-webkit-user-modify: read-write;overflow-wrap: break-word;-webkit-line-break: after-white-space;-webkit-user-select: auto;}:where([draggable="true"]) {-webkit-user-drag: element;}:where(dialog:modal) {all: revert;}
+  </style>
+
+  <style>
+    body {min-height: 100vh;}
+  </style>
+</head>
+<body>
+  <div style="width: 100%; height: 100vh;" id='embedded-sandbox'></div>
+  <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js"></script>
+  <script>
+    new window.EmbeddedSandbox({
+      target: '#embedded-sandbox',
+      initialEndpoint: <%= default_url %>,
+      initialState: {
+        headers: JSON.stringify(<%= default_headers %>),
+        variables: '<%= variables_string %>',
+        document: '<%= query_string %>'
+      }
+    });
+  </script>
+</body>
+</html>

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Absinthe.Plug.Mixfile do
   use Mix.Project
 
-  @version "1.5.8"
+  @version "1.6.0"
 
   def project do
     [


### PR DESCRIPTION
Playground project has been [deprecated in Dec 2022](https://www.apollographql.com/docs/apollo-server/v2/testing/graphql-playground/) giving space to [Apollo's Explorer embedded Sandbox](https://www.apollographql.com/docs/graphos/explorer/sandbox#embedding-sandbox) (free -- no account required).

In this PR:
- Added support for Apollo's Explorer Sandbox interface (`:apollo_explorer_sandbox`) and updated docs;
- Minor refac on `Absinthe.Plug.GraphiQL`'s private functions;
- Bumped `absinthe_plug` version from `1.5.8` to `1.6.0`.