### PR TITLE
Update assets.ex

### DIFF
--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -40,7 +40,7 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
        "graphiql.css",
        {"graphiql.min.js", "graphiql.js"}
      ]},
-    {"graphiql-workspace", "1.1.4",
+    {"graphiql-workspace", "1.1.5",
      [
        "graphiql-workspace.css",
        {"graphiql-workspace.min.js", "graphiql-workspace.js"}


### PR DESCRIPTION
The main point of the update is bugs in `graphiql-workspace` 1.1.4 and fixes in version 1.1.5.

For example, the default values of custom scalars are always displayed as `false` instead of the actual value, because issue in function:
```
 function buildScalarDef(scalarIntrospection) {
    return new _definition.GraphQLScalarType({
      name: scalarIntrospection.name,
      description: scalarIntrospection.description,
      serialize: function serialize(id) {
        return id;
      },
      // Note: validation calls the parse functions to determine if a
      // literal value is correct. Returning null would cause use of custom
      // scalars to always fail validation. Returning false causes them to
      // always pass validation.
      parseValue: function parseValue() {
        return false;
      },
      parseLiteral: function parseLiteral() {
        return false;
      }
    });
  }
```
This bug has been fixed in version 1.1.5.

In this PR:
- updated the `graphiql-workspace` asset from version 1.1.4 to version 1.1.5