### PR TITLE
Use runtime config for assets

### DIFF
--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -163,7 +163,6 @@ defmodule Absinthe.Plug.GraphiQL do
           interface: :playground | :advanced | :simple,
           default_headers: {module, atom},
           default_url: binary,
-          assets: Keyword.t(),
           socket: module,
           socket_url: binary
         ]

--- a/lib/absinthe/plug/graphiql/assets.ex
+++ b/lib/absinthe/plug/graphiql/assets.ex
@@ -2,7 +2,6 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
   @moduledoc """
   """
 
-  @config Application.compile_env(:absinthe_plug, Absinthe.Plug.GraphiQL)
   @default_config [
     source: :smart,
     local_url_path: "/absinthe_graphiql",
@@ -72,10 +71,13 @@ defmodule Absinthe.Plug.GraphiQL.Assets do
      ]}
   ]
 
-  if @config do
-    def assets_config, do: Keyword.merge(@default_config, Keyword.get(config, :assets, []))
-  else
-    def assets_config, do: @default_config
+  def assets_config do
+    runtime_config =
+      :absinthe_plug
+      |> Application.get_env(Absinthe.Plug.GraphiQL, [])
+      |> Keyword.get(:assets, [])
+
+    Keyword.merge(@default_config, runtime_config)
   end
 
   def get_assets do


### PR DESCRIPTION
Summary of the PR:

* Use runtime config instead of compile time

The main use case for providing runtime config is to override `local_directory` option when using Elixir releases:

```
# config/runtime.exs
config :absinthe_plug, Absinthe.Plug.GraphiQL,
    assets: [
      source: :smart,
      local_url_path: "/absinthe_graphiql",
      local_directory: Path.join(Application.app_dir(:my_app), "priv/static/absinthe_graphiql")
    ]
```

The above is a method to use patched version of `@absinthe/socket` dependency which fixes the missing headers bug (see https://github.com/absinthe-graphql/absinthe-socket/pull/67)

As far as I know this cannot be achieved using compile-time configuration, because `Application.app_dir(:my_app)` is not available at that time. Besides, compile-time configuration didn't work anyway - it was inducing a compilation error.

* Remove `assets` option from plug's `init/1` type specification, because it was not used there.