### PR TITLE
fix: XSS vulnerability in GraphiQL js_escape

### DIFF
--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -395,8 +395,11 @@ defmodule Absinthe.Plug.GraphiQL do
 
   defp js_escape(string) do
     string
-    |> String.replace(~r/\n/, "\\n")
-    |> String.replace(~r/'/, "\\'")
+    |> String.replace("\\", "\\\\")
+    |> String.replace("'", "\\'")
+    |> String.replace("\n", "\\n")
+    |> String.replace("\r", "\\r")
+    |> String.replace("</", "<\\/")
   end
 
   defp handle_default_headers(config, conn) do

--- a/test/lib/absinthe/graphiql_test.exs
+++ b/test/lib/absinthe/graphiql_test.exs
@@ -232,6 +232,27 @@ defmodule Absinthe.Plug.GraphiQLTest do
     assert String.contains?(body, "defaultWebsocketUrl: ''")
   end
 
+  test "query parameter is properly escaped against XSS" do
+    opts = Absinthe.Plug.GraphiQL.init(schema: TestSchema)
+
+    # This payload would break out of a JS string if backslashes aren't escaped.
+    # Without the fix: xxx\');confirm(document.domain);// would close the string.
+    # With the fix: backslashes are escaped so the string stays intact.
+    xss_payload = "xxx\\');confirm(document.domain);//"
+
+    assert %{status: 200, resp_body: body} =
+             conn(:get, "/?query=#{URI.encode(xss_payload)}")
+             |> plug_parser
+             |> put_req_header("accept", "text/html")
+             |> Absinthe.Plug.GraphiQL.call(opts)
+
+    # The payload must NOT appear as unquoted JS code.
+    # With proper escaping, the backslash before the quote is escaped (\\'),
+    # so the quote doesn't close the string and the code never executes.
+    # We check that the escaped version is present (backslash is doubled).
+    assert String.contains?(body, "xxx\\\\\\');confirm")
+  end
+
   defp plug_parser(conn) do
     opts =
       Plug.Parsers.init(


### PR DESCRIPTION
Found this while reviewing the security of our GraphQL setup at Shiko (veterinary platform). The `js_escape` function in GraphiQL only escapes newlines and single quotes, but not backslashes. This means you can bypass the escaping with `\'` and break out of the JavaScript string to execute arbitrary code.

The reproduction from #275 still works on the current version:

```
/graphiql?query=xxx\%27});confirm(document.domain);%20var%20x=new%20graphiqlWorkspace.AppConfig(%22x%22,{//
```

## The fix

Escape backslashes before anything else in `js_escape`, and also handle carriage returns and `</script>` injection:

```elixir
defp js_escape(string) do
  string
  |> String.replace("\\", "\\\\")
  |> String.replace("'", "\\'")
  |> String.replace("\n", "\\n")
  |> String.replace("\r", "\\r")
  |> String.replace("</", "<\\/")
end
```

The order matters: backslashes must be escaped first so we don't double-escape the backslashes we introduce in later replacements.

Added a test that verifies the XSS payload gets properly escaped.

Fixes #275