### PR TITLE
chore: Add Sobelow security scanning

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -97,3 +97,19 @@ jobs:
 
       - name: Run Dialyzer
         run: mix dialyzer
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          elixir-version: "1.18"
+
+      - name: Install package dependencies
+        run: mix deps.get
+
+      - name: Run Sobelow
+        run: mix sobelow --conf

--- a/.sobelow-conf
+++ b/.sobelow-conf
@@ -1,0 +1,12 @@
+[
+  verbose: false,
+  private: true,
+  skip: true,
+  router: nil,
+  exit: :low,
+  format: "txt",
+  out: nil,
+  threshold: :low,
+  ignore_files: [],
+  version: false,
+]

--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -596,6 +596,10 @@ defmodule Absinthe.Plug do
 
   @doc false
   @spec encode(Plug.Conn.t(), 200 | 400 | 405 | 500, map | list, map) :: Plug.Conn.t() | no_return
+  # `content_type` and the serializer `mod` are fixed configuration values on the Plug
+  # (supplied by the host application), not derived from request data. Likewise, the body
+  # is serialized by the host application via an explicit opt-in.
+  # sobelow_skip ["XSS.ContentType", "XSS.SendResp"]
   def encode(conn, status, body, %{
         serializer: %{module: mod, opts: opts},
         content_type: content_type

--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -205,6 +205,11 @@ defmodule Absinthe.Plug.GraphiQL do
     end
   end
 
+  # The `{:input_error, msg}` and `{:error, error, _}` branches return plain-text
+  # diagnostic strings (a fixed `"Could not parse JSON. ..."` prefix, or an
+  # Absinthe-generated message). Neither is sent with a `text/html` content type,
+  # and therefore should not be rendered as HTML by the browser.
+  # sobelow_skip ["XSS.SendResp"]
   defp do_call(conn, %{interface: interface} = config) do
     config =
       config
@@ -387,6 +392,11 @@ defmodule Absinthe.Plug.GraphiQL do
   defp default_url(url), do: "'#{url}'"
 
   @spec rendered(String.t(), Plug.Conn.t()) :: Plug.Conn.t()
+  # This is the GraphiQL developer interface, intentionally served as text/html.
+  # Every request-derived value embedded in the page (the query, the variables, and
+  # the result) is passed through `js_escape/1` before interpolation into the script
+  # context, neutralizing markup/script breakout.
+  # sobelow_skip ["XSS.SendResp"]
   defp rendered(html, conn) do
     conn
     |> put_resp_content_type("text/html")

--- a/lib/absinthe/plug/graphiql.ex
+++ b/lib/absinthe/plug/graphiql.ex
@@ -391,12 +391,12 @@ defmodule Absinthe.Plug.GraphiQL do
   defp default_url(nil), do: "window.location.origin + window.location.pathname"
   defp default_url(url), do: "'#{url}'"
 
-  @spec rendered(String.t(), Plug.Conn.t()) :: Plug.Conn.t()
-  # This is the GraphiQL developer interface, intentionally served as text/html.
-  # Every request-derived value embedded in the page (the query, the variables, and
-  # the result) is passed through `js_escape/1` before interpolation into the script
-  # context, neutralizing markup/script breakout.
+  # The GraphiQL developer interface is intentionally served as `text/html`.
+  # Every request-derived value embedded in the page (the query, variables, and result)
+  # passes through `js_escape/1` before interpolation into `render_interface/3`,
+  # neutralizing XSS injection.
   # sobelow_skip ["XSS.SendResp"]
+  @spec rendered(String.t(), Plug.Conn.t()) :: Plug.Conn.t()
   defp rendered(html, conn) do
     conn
     |> put_resp_content_type("text/html")

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,8 @@ defmodule Absinthe.Plug.Mixfile do
       {:plug, "~> 1.4"},
       {:jason, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.20", only: :dev},
-      {:dialyxir, "~> 1.3", only: [:dev, :test], runtime: false}
+      {:dialyxir, "~> 1.3", only: [:dev, :test], runtime: false},
+      {:sobelow, ">= 0.14.0", only: [:dev], runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [:mix], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
   "plug": {:hex, :plug, "1.14.2", "cff7d4ec45b4ae176a227acd94a7ab536d9b37b942c8e8fa6dfc0fff98ff4d80", [:mix], [{:mime, "~> 1.0 or ~> 2.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.3 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "842fc50187e13cf4ac3b253d47d9474ed6c296a8732752835ce4a86acdf68d13"},
   "plug_crypto": {:hex, :plug_crypto, "1.2.5", "918772575e48e81e455818229bf719d4ab4181fcbf7f85b68a35620f78d89ced", [:mix], [], "hexpm", "26549a1d6345e2172eb1c233866756ae44a9609bd33ee6f99147ab3fd87fd842"},
+  "sobelow": {:hex, :sobelow, "0.14.1", "2f81e8632f15574cba2402bcddff5497b413c01e6f094bc0ab94e83c2f74db81", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "8fac9a2bd90fdc4b15d6fca6e1608efb7f7c600fa75800813b794ee9364c87f2"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
 }


### PR DESCRIPTION
In response to the rash of CVEs from vulnerabilities that static analysis can detect (see [the EEF's list of most common weaknesses](https://cna.erlef.org/common-weaknesses), of which uncontrolled resource consumption like as atom table exhaustion is number 1), I thought it might be valuable to add Sobelow scanning to the project. It didn't find anything actionable (yay! 🎉), but I figured it might still be good to have it running in CI so that future potential vulnerabilities can be called out.